### PR TITLE
Insert empty line between <a> and subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <a name="table"></a>
+
 # Table
 
 [![Travis build status](http://img.shields.io/travis/gajus/table/master.svg?style=flat)](https://travis-ci.org/gajus/table)
@@ -24,6 +25,7 @@ Produces a string that represents array data in a text table.
 ![Demo of table displaying a list of missions to the Moon.](./.README/demo.png)
 
 <a name="table-features"></a>
+
 ## Features
 
 * Works with strings containing [fullwidth](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms) characters.
@@ -35,6 +37,7 @@ Produces a string that represents array data in a text table.
 * Text wrapping.
 
 <a name="table-usage"></a>
+
 ## Usage
 
 Table data is described using an array (rows) of array (cells).
@@ -134,6 +137,7 @@ console.log(output);
 
 
 <a name="table-usage-cell-content-alignment"></a>
+
 ### Cell Content Alignment
 
 `{string} config.columns[{number}].alignment` property controls content horizontal alignment within a cell.
@@ -184,6 +188,7 @@ console.log(output);
 ```
 
 <a name="table-usage-column-width"></a>
+
 ### Column Width
 
 `{number} config.columns[{number}].width` property restricts column width to a fixed width.
@@ -223,6 +228,7 @@ console.log(output);
 ```
 
 <a name="table-usage-custom-border"></a>
+
 ### Custom Border
 
 `{object} config.border` property describes characters used to draw the table border.
@@ -277,6 +283,7 @@ console.log(output);
 ```
 
 <a name="table-usage-draw-horizontal-line"></a>
+
 ### Draw Horizontal Line
 
 `{function} config.drawHorizontalLine` property is a function that is called for every non-content row in the table. The result of the function `{boolean}` determines whether a row is drawn.
@@ -324,6 +331,7 @@ console.log(output);
 ```
 
 <a name="table-usage-padding-cell-content"></a>
+
 ### Padding Cell Content
 
 `{number} config.columns[{number}].paddingLeft` and `{number} config.columns[{number}].paddingRight` properties control content padding within a cell. Property value represents a number of whitespaces used to pad the content.
@@ -369,6 +377,7 @@ console.log(output);
 ```
 
 <a name="table-usage-predefined-border-templates"></a>
+
 ### Predefined Border Templates
 
 You can load one of the predefined border templates using `getBorderCharacters` function.
@@ -439,6 +448,7 @@ table(data, config);
 Raise [an issue](https://github.com/gajus/table/issues) if you'd like to contribute a new border template.
 
 <a name="table-usage-predefined-border-templates-borderless-table"></a>
+
 #### Borderless Table
 
 Simply using "void" border character template creates a table with a lot of unnecessary spacing.
@@ -469,6 +479,7 @@ console.log(output);
 ```
 
 <a name="table-usage-streaming"></a>
+
 ### Streaming
 
 `table` package exports `createStream` function used to draw a table and append rows.
@@ -549,7 +560,9 @@ setInterval(() => {
 ```
 
 ![Streaming random data.](./.README/streaming-random.gif)
+
 <a name="table-usage-text-truncation"></a>
+
 ### Text Truncation
 
 To handle a content that overflows the container width, `table` package implements [text wrapping](#table-usage-text-wrapping). However, sometimes you may want to truncate content that is too long to be displayed in the table.
@@ -590,6 +603,7 @@ console.log(output);
 ```
 
 <a name="table-usage-text-wrapping"></a>
+
 ### Text Wrapping
 
 `table` package implements auto text wrapping, i.e. text that has width greater than the container width will be separated into multiple lines, e.g.


### PR DESCRIPTION
### Reason

Because heading doesn't look good in [npm page](https://www.npmjs.com/package/table)
![image](https://user-images.githubusercontent.com/11488886/28607774-8c811db8-7207-11e7-9d59-dd82e72b887f.png)

### Changes

* For each pair of named anchor (`<a name=...></a>`) and subtitle (`## ...`), insert an empty line in between