### PR TITLE
Move ajv to dev dependencies and update to version 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "ajv": "^5.2.3",
-    "ajv-keywords": "^2.1.1",
     "chalk": "^2.1.0",
     "lodash": "^4.17.4",
     "slice-ansi": "1.0.0",
@@ -14,7 +12,9 @@
   },
   "description": "Formats data into a string table.",
   "devDependencies": {
+    "ajv": "^5.5.2",
     "ajv-cli": "^2.1.0",
+    "ajv-keywords": "^2.1.1",
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "description": "Formats data into a string table.",
   "devDependencies": {
-    "ajv": "^5.5.2",
-    "ajv-cli": "^2.1.0",
-    "ajv-keywords": "^2.1.1",
+    "ajv": "^6.0.1",
+    "ajv-cli": "^3.0.0",
+    "ajv-keywords": "^3.0.0",
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",

--- a/test/config.js
+++ b/test/config.js
@@ -3,6 +3,8 @@ import {
 } from 'chai';
 import Ajv from 'ajv';
 import ajvKeywords from 'ajv-keywords';
+import ajvSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
+
 import validateConfig from '../dist/validateConfig';
 import configSchema from '../src/schemas/config.json';
 import configSamples from './configSamples';
@@ -12,6 +14,7 @@ describe('config.json schema', () => {
 
   before(() => {
     const ajv = new Ajv({allErrors: true});
+    ajv.addMetaSchema(ajvSchemaDraft06);
 
     ajvKeywords(ajv, 'typeof');
     validate = ajv.compile(configSchema);

--- a/test/streamConfig.js
+++ b/test/streamConfig.js
@@ -3,6 +3,8 @@ import {
 } from 'chai';
 import Ajv from 'ajv';
 import ajvKeywords from 'ajv-keywords';
+import ajvSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
+
 import validateConfig from '../dist/validateStreamConfig';
 import configSchema from '../src/schemas/streamConfig.json';
 import configSamples from './streamConfigSamples';
@@ -14,6 +16,7 @@ describe('streamConfig.json schema', () => {
     const ajv = new Ajv({
       allErrors: true
     });
+    ajv.addMetaSchema(ajvSchemaDraft06);
 
     ajvKeywords(ajv, 'typeof');
 


### PR DESCRIPTION
Since ajv is only used in tests it should be a dev dependency. While I'm at it, I also updated it to version 6.

I didn't migrate the schema to version 7, that might be considered a breaking change.