### PR TITLE
Replace lodash with native ES5/ES6 methods where possible

### DIFF
--- a/src/alignString.js
+++ b/src/alignString.js
@@ -13,7 +13,7 @@ const alignments = [
  * @returns {string}
  */
 const alignLeft = (subject, width) => {
-  return subject + _.repeat(' ', width);
+  return subject + ' '.repeat(width);
 };
 
 /**
@@ -22,7 +22,7 @@ const alignLeft = (subject, width) => {
  * @returns {string}
  */
 const alignRight = (subject, width) => {
-  return _.repeat(' ', width) + subject;
+  return ' '.repeat(width) + subject;
 };
 
 /**
@@ -36,11 +36,11 @@ const alignCenter = (subject, width) => {
   halfWidth = width / 2;
 
   if (halfWidth % 2 === 0) {
-    return _.repeat(' ', halfWidth) + subject + _.repeat(' ', halfWidth);
+    return ' '.repeat(halfWidth) + subject + ' '.repeat(halfWidth);
   } else {
     halfWidth = _.floor(halfWidth);
 
-    return _.repeat(' ', halfWidth) + subject + _.repeat(' ', halfWidth + 1);
+    return ' '.repeat(halfWidth) + subject + ' '.repeat(halfWidth + 1);
   }
 };
 
@@ -79,7 +79,7 @@ export default (subject, containerWidth, alignment) => {
   }
 
   if (subjectWidth === 0) {
-    return _.repeat(' ', containerWidth);
+    return ' '.repeat(containerWidth);
   }
 
   const availableWidth = containerWidth - subjectWidth;

--- a/src/alignString.js
+++ b/src/alignString.js
@@ -38,7 +38,7 @@ const alignCenter = (subject, width) => {
   if (halfWidth % 2 === 0) {
     return ' '.repeat(halfWidth) + subject + ' '.repeat(halfWidth);
   } else {
-    halfWidth = _.floor(halfWidth);
+    halfWidth = Math.floor(halfWidth);
 
     return ' '.repeat(halfWidth) + subject + ' '.repeat(halfWidth + 1);
   }

--- a/src/calculateCellHeight.js
+++ b/src/calculateCellHeight.js
@@ -25,5 +25,5 @@ export default (value, columnWidth, useWrapWord = false) => {
     return wrapWord(value, columnWidth).length;
   }
 
-  return _.ceil(stringWidth(value) / columnWidth);
+  return Math.ceil(stringWidth(value) / columnWidth);
 };

--- a/src/calculateCellHeight.js
+++ b/src/calculateCellHeight.js
@@ -13,7 +13,7 @@ export default (value, columnWidth, useWrapWord = false) => {
     throw new TypeError('Value must be a string.');
   }
 
-  if (!_.isInteger(columnWidth)) {
+  if (!Number.isInteger(columnWidth)) {
     throw new TypeError('Column width must be an integer.');
   }
 

--- a/src/calculateMaximumColumnWidthIndex.js
+++ b/src/calculateMaximumColumnWidthIndex.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import calculateCellWidthIndex from './calculateCellWidthIndex';
 
 /**
@@ -14,10 +13,10 @@ export default (rows) => {
 
   const columns = Array(rows[0].length).fill(0);
 
-  _.forEach(rows, (row) => {
+  rows.forEach((row) => {
     const columnWidthIndex = calculateCellWidthIndex(row);
 
-    _.forEach(columnWidthIndex, (valueWidth, index0) => {
+    columnWidthIndex.forEach((valueWidth, index0) => {
       if (columns[index0] < valueWidth) {
         columns[index0] = valueWidth;
       }

--- a/src/calculateMaximumColumnWidthIndex.js
+++ b/src/calculateMaximumColumnWidthIndex.js
@@ -12,7 +12,7 @@ export default (rows) => {
     throw new Error('Dataset must have at least one row.');
   }
 
-  const columns = _.fill(Array(rows[0].length), 0);
+  const columns = Array(rows[0].length).fill(0);
 
   _.forEach(rows, (row) => {
     const columnWidthIndex = calculateCellWidthIndex(row);

--- a/src/calculateRowHeightIndex.js
+++ b/src/calculateRowHeightIndex.js
@@ -14,7 +14,7 @@ export default (rows, config) => {
   const rowSpanIndex = [];
 
   _.forEach(rows, (cells) => {
-    const cellHeightIndex = _.fill(Array(tableWidth), 1);
+    const cellHeightIndex = Array(tableWidth).fill(1);
 
     _.forEach(cells, (value, index1) => {
       if (!_.isNumber(config.columns[index1].width)) {

--- a/src/calculateRowHeightIndex.js
+++ b/src/calculateRowHeightIndex.js
@@ -13,10 +13,10 @@ export default (rows, config) => {
 
   const rowSpanIndex = [];
 
-  _.forEach(rows, (cells) => {
+  rows.forEach((cells) => {
     const cellHeightIndex = Array(tableWidth).fill(1);
 
-    _.forEach(cells, (value, index1) => {
+    cells.forEach((value, index1) => {
       if (!_.isNumber(config.columns[index1].width)) {
         throw new TypeError('column[index].width must be a number.');
       }

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -43,7 +43,7 @@ const prepareData = (data, config) => {
 const create = (row, columnWidthIndex, config) => {
   const rows = prepareData([row], config);
 
-  const body = _.map(rows, (literalRow) => {
+  const body = rows.map((literalRow) => {
     return drawRow(literalRow, config.border);
   }).join('');
 
@@ -69,7 +69,7 @@ const create = (row, columnWidthIndex, config) => {
 const append = (row, columnWidthIndex, config) => {
   const rows = prepareData([row], config);
 
-  const body = _.map(rows, (literalRow) => {
+  const body = rows.map((literalRow) => {
     return drawRow(literalRow, config.border);
   }).join('');
 

--- a/src/drawBorder.js
+++ b/src/drawBorder.js
@@ -16,7 +16,7 @@ import _ from 'lodash';
 const drawBorder = (columnSizeIndex, parts) => {
   const columns = _
     .map(columnSizeIndex, (size) => {
-      return _.repeat(parts.body, size);
+      return parts.body.repeat(size);
     })
     .join(parts.join);
 

--- a/src/drawBorder.js
+++ b/src/drawBorder.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 /**
  * @typedef drawBorder~parts
  * @property {string} left
@@ -14,8 +12,8 @@ import _ from 'lodash';
  * @returns {string}
  */
 const drawBorder = (columnSizeIndex, parts) => {
-  const columns = _
-    .map(columnSizeIndex, (size) => {
+  const columns = columnSizeIndex
+    .map((size) => {
       return parts.body.repeat(size);
     })
     .join(parts.join);

--- a/src/drawTable.js
+++ b/src/drawTable.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {
   drawBorderTop,
   drawBorderJoin,
@@ -29,7 +28,7 @@ export default (rows, border, columnSizeIndex, rowSpanIndex, drawHorizontalLine)
     output += drawBorderTop(columnSizeIndex, border);
   }
 
-  _.forEach(rows, (row, index0) => {
+  rows.forEach((row, index0) => {
     output += drawRow(row, border);
 
     if (!rowHeight) {

--- a/src/makeConfig.js
+++ b/src/makeConfig.js
@@ -30,7 +30,7 @@ const makeColumns = (rows, columns = {}, columnDefault = {}) => {
       columns[index] = {};
     }
 
-    columns[index] = _.assign({
+    columns[index] = Object.assign({
       alignment: 'left',
       paddingLeft: 1,
       paddingRight: 1,

--- a/src/mapDataUsingRowHeightIndex.js
+++ b/src/mapDataUsingRowHeightIndex.js
@@ -13,7 +13,7 @@ export default (unmappedRows, rowHeightIndex, config) => {
 
   const mappedRows = unmappedRows.map((cells, index0) => {
     const rowHeight = _.times(rowHeightIndex[index0], () => {
-      return _.fill(Array(tableWidth), '');
+      return Array(tableWidth).fill('');
     });
 
     // rowHeight

--- a/src/mapDataUsingRowHeightIndex.js
+++ b/src/mapDataUsingRowHeightIndex.js
@@ -20,7 +20,7 @@ export default (unmappedRows, rowHeightIndex, config) => {
     //     [{row index within rowSaw; index2}]
     //     [{cell index within a virtual row; index1}]
 
-    _.forEach(cells, (value, index1) => {
+    cells.forEach((value, index1) => {
       let chunkedValue;
 
       if (config.columns[index1].wrapWord) {
@@ -29,7 +29,7 @@ export default (unmappedRows, rowHeightIndex, config) => {
         chunkedValue = wrapString(value, config.columns[index1].width);
       }
 
-      _.forEach(chunkedValue, (part, index2) => {
+      chunkedValue.forEach((part, index2) => {
         rowHeight[index2][index1] = part;
       });
     });

--- a/src/padTableData.js
+++ b/src/padTableData.js
@@ -1,13 +1,11 @@
-import _ from 'lodash';
-
 /**
  * @param {table~row[]} rows
  * @param {Object} config
  * @returns {table~row[]}
  */
 export default (rows, config) => {
-  return _.map(rows, (cells) => {
-    return _.map(cells, (value, index1) => {
+  return rows.map((cells) => {
+    return cells.map((value, index1) => {
       const column = config.columns[index1];
 
       return ' '.repeat(column.paddingLeft) + value + ' '.repeat(column.paddingRight);

--- a/src/padTableData.js
+++ b/src/padTableData.js
@@ -10,7 +10,7 @@ export default (rows, config) => {
     return _.map(cells, (value, index1) => {
       const column = config.columns[index1];
 
-      return _.repeat(' ', column.paddingLeft) + value + _.repeat(' ', column.paddingRight);
+      return ' '.repeat(column.paddingLeft) + value + ' '.repeat(column.paddingRight);
     });
   });
 };

--- a/src/truncateTableData.js
+++ b/src/truncateTableData.js
@@ -7,8 +7,8 @@ import _ from 'lodash';
  * @returns {table~row[]}
  */
 export default (rows, config) => {
-  return _.map(rows, (cells) => {
-    return _.map(cells, (content, index) => {
+  return rows.map((cells) => {
+    return cells.map((content, index) => {
       return _.truncate(content, {
         length: config.columns[index].truncate
       });

--- a/src/wrapString.js
+++ b/src/wrapString.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import slice from 'slice-ansi';
 import stringWidth from 'string-width';
 
@@ -23,7 +22,7 @@ export default (subject, size) => {
   do {
     chunks.push(slice(subjectSlice, 0, size));
 
-    subjectSlice = _.trim(slice(subjectSlice, size));
+    subjectSlice = slice(subjectSlice, size).trim();
   } while (stringWidth(subjectSlice));
 
   return chunks;

--- a/src/wrapWord.js
+++ b/src/wrapWord.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import slice from 'slice-ansi';
 import stringWidth from 'string-width';
 
@@ -27,7 +26,7 @@ export default (input, size) => {
 
       subject = slice(subject, stringWidth(chunk));
 
-      chunk = _.trim(chunk);
+      chunk = chunk.trim();
     } else {
       chunk = slice(subject, 0, size);
       subject = slice(subject, size);


### PR DESCRIPTION
Not much usage of lodash left but anything that is left has no simple replacement (in Node 4).