### PR TITLE
Support Node.js 6.9

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["env", {"targets": {"node": "4"}}]
+    ["env", {"targets": {"node": "6.9"}}]
   ],
   "env": {
     "development": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
 node_js:
   - 10
   - 8
+  - 6
 notifications:
   email: false
 sudo: false

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sinon": "^4.0.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": "^6.9"
   },
   "keywords": [
     "ascii",

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -93,7 +93,7 @@ const append = (row, columnWidthIndex, config) => {
 export default (userConfig = {}) => {
   const config = makeStreamConfig(userConfig);
 
-  const columnWidthIndex = Object.values(_.mapValues(config.columns, (column) => {
+  const columnWidthIndex = _.values(_.mapValues(config.columns, (column) => {
     return column.width + column.paddingLeft + column.paddingRight;
   }));
 


### PR DESCRIPTION
Since Node.js 6 is still in LTS, I think it'd be better if it was continued to be supported.