### PR TITLE
Use lodash's _.values() to drop the dependency on object.values

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "ajv": "^6.5.3",
     "lodash": "^4.17.10",
-    "object.values": "^1.0.4",
     "slice-ansi": "1.0.0",
     "string-width": "^2.1.1"
   },

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import values from 'object.values';
 import makeStreamConfig from './makeStreamConfig';
 import drawRow from './drawRow';
 import {
@@ -94,8 +93,8 @@ const append = (row, columnWidthIndex, config) => {
 export default (userConfig = {}) => {
   const config = makeStreamConfig(userConfig);
 
-  // @todo Drop 'object.values' dependency when Node.js v6 support is dropped.
-  const columnWidthIndex = values(_.mapValues(config.columns, (column) => {
+  // @todo Use 'Object.values' when Node.js v6 support is dropped.
+  const columnWidthIndex = _.values(_.mapValues(config.columns, (column) => {
     return column.width + column.paddingLeft + column.paddingRight;
   }));
 


### PR DESCRIPTION
Always nice to have less dependencies and `object.values` pulls in a lot of them (it has 4 dependencies).