### PR TITLE
Indicate support for Node.js 6 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sinon": "^6.1.5"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=6.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Otherwise installation will fail with yarn on Node.js 6