### PR TITLE
Accept newlines passed into table data

### DIFF
--- a/src/validateTableData.js
+++ b/src/validateTableData.js
@@ -34,11 +34,9 @@ export default (rows) => {
       throw new Error('Table must have a consistent number of cells.');
     }
 
-    // @todo Make an exception for newline characters.
-    // @see https://github.com/gajus/table/issues/9
     for (const cell of cells) {
       // eslint-disable-next-line no-control-regex
-      if (/[\u0001-\u001A]/.test(cell)) {
+      if (/[\u0001-\u0009\u000B-\u001A]/.test(cell)) {
         throw new Error('Table data must not contain control characters.');
       }
     }

--- a/test/validateTableData.js
+++ b/test/validateTableData.js
@@ -52,6 +52,12 @@ describe('validateTableData', () => {
     });
   });
 
+  context('cell data contains newlines', () => {
+    it('does not throw', () => {
+      validateTableData([['ab\nc']]);
+    });
+  });
+
   context('rows have inconsistent number of cells', () => {
     it('throws an error', () => {
       expect(() => {


### PR DESCRIPTION
This is a follow-up PR to https://github.com/gajus/table/pull/88, sorry about that.

I had missed that the newlines would be filtered out by `validateTableData()`, they now no longer are.