### PR TITLE
Lax slice-ansi dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "ajv": "^6.6.1",
     "lodash": "^4.17.11",
-    "slice-ansi": "2.0.0",
+    "slice-ansi": "^2.0.0",
     "string-width": "^2.1.1"
   },
   "description": "Formats data into a string table.",


### PR DESCRIPTION
Is there a reason to why slice-ansi can't use the caret range like the rest of the dependencies?

Slice-ansi was just [recently updated to v2.1.0](https://github.com/chalk/slice-ansi/releases/tag/v2.1.0), the current version pin prevents that fix from being available here (as well as future minor/patch changes).