### PR TITLE
feature: Single line mode (compact)

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -29,6 +29,7 @@ Produces a string that represents array data in a text table.
 {"gitdown": "include", "file": "./usage/column_width.md"}
 {"gitdown": "include", "file": "./usage/custom_border.md"}
 {"gitdown": "include", "file": "./usage/draw_horizontal_line.md"}
+{"gitdown": "include", "file": "./usage/single_line_mode.md"}
 {"gitdown": "include", "file": "./usage/padding_cell_content.md"}
 {"gitdown": "include", "file": "./usage/predefined_border_templates.md"}
 {"gitdown": "include", "file": "./usage/streaming.md"}

--- a/.README/usage/single_line_mode.md
+++ b/.README/usage/single_line_mode.md
@@ -1,0 +1,41 @@
+### Single Line Mode
+
+Horizontal lines inside the table are not drawn.
+
+```js
+import {
+  table,
+  getBorderCharacters
+} from 'table';
+
+const data = [
+  ['-rw-r--r--', '1', 'pandorym', 'staff', '1529', 'May 23 11:25', 'LICENSE'],
+  ['-rw-r--r--', '1', 'pandorym', 'staff', '16327', 'May 23 11:58', 'README.md'],
+  ['drwxr-xr-x', '76', 'pandorym', 'staff', '2432', 'May 23 12:02', 'dist'],
+  ['drwxr-xr-x', '634', 'pandorym', 'staff', '20288', 'May 23 11:54', 'node_modules'],
+  ['-rw-r--r--', '1,', 'pandorym', 'staff', '525688', 'May 23 11:52', 'package-lock.json'],
+  ['-rw-r--r--@', '1', 'pandorym', 'staff', '2440', 'May 23 11:25', 'package.json'],
+  ['drwxr-xr-x', '27', 'pandorym', 'staff', '864', 'May 23 11:25', 'src'],
+  ['drwxr-xr-x', '20', 'pandorym', 'staff', '640', 'May 23 11:25', 'test'],
+];
+
+const config = {
+  singleLine: true
+};
+
+const output = table(data, config);
+console.log(output);
+```
+
+```
+╔═════════════╤═════╤══════════╤═══════╤════════╤══════════════╤═══════════════════╗
+║ -rw-r--r--  │ 1   │ pandorym │ staff │ 1529   │ May 23 11:25 │ LICENSE           ║
+║ -rw-r--r--  │ 1   │ pandorym │ staff │ 16327  │ May 23 11:58 │ README.md         ║
+║ drwxr-xr-x  │ 76  │ pandorym │ staff │ 2432   │ May 23 12:02 │ dist              ║
+║ drwxr-xr-x  │ 634 │ pandorym │ staff │ 20288  │ May 23 11:54 │ node_modules      ║
+║ -rw-r--r--  │ 1,  │ pandorym │ staff │ 525688 │ May 23 11:52 │ package-lock.json ║
+║ -rw-r--r--@ │ 1   │ pandorym │ staff │ 2440   │ May 23 11:25 │ package.json      ║
+║ drwxr-xr-x  │ 27  │ pandorym │ staff │ 864    │ May 23 11:25 │ src               ║
+║ drwxr-xr-x  │ 20  │ pandorym │ staff │ 640    │ May 23 11:25 │ test              ║
+╚═════════════╧═════╧══════════╧═══════╧════════╧══════════════╧═══════════════════╝
+```

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ dist
 !.gitignore
 !.npmignore
 !.travis.yml
-!.README

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 !.gitignore
 !.npmignore
 !.travis.yml
+!.README

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
         * [Column Width](#table-usage-column-width)
         * [Custom Border](#table-usage-custom-border)
         * [Draw Horizontal Line](#table-usage-draw-horizontal-line)
+        * [Single Line Mode](#table-usage-single-line-mode)
         * [Padding Cell Content](#table-usage-padding-cell-content)
         * [Predefined Border Templates](#table-usage-predefined-border-templates)
         * [Streaming](#table-usage-streaming)
@@ -339,6 +340,49 @@ console.log(output);
 ║ 4A │ 4B │ 4C ║
 ╚════╧════╧════╝
 
+```
+
+<a name="table-usage-single-line-mode"></a>
+### Single Line Mode
+
+Horizontal lines inside the table are not drawn.
+
+```js
+import {
+  table,
+  getBorderCharacters
+} from 'table';
+
+const data = [
+  ['-rw-r--r--', '1', 'pandorym', 'staff', '1529', 'May 23 11:25', 'LICENSE'],
+  ['-rw-r--r--', '1', 'pandorym', 'staff', '16327', 'May 23 11:58', 'README.md'],
+  ['drwxr-xr-x', '76', 'pandorym', 'staff', '2432', 'May 23 12:02', 'dist'],
+  ['drwxr-xr-x', '634', 'pandorym', 'staff', '20288', 'May 23 11:54', 'node_modules'],
+  ['-rw-r--r--', '1,', 'pandorym', 'staff', '525688', 'May 23 11:52', 'package-lock.json'],
+  ['-rw-r--r--@', '1', 'pandorym', 'staff', '2440', 'May 23 11:25', 'package.json'],
+  ['drwxr-xr-x', '27', 'pandorym', 'staff', '864', 'May 23 11:25', 'src'],
+  ['drwxr-xr-x', '20', 'pandorym', 'staff', '640', 'May 23 11:25', 'test'],
+];
+
+const config = {
+  singleLine: true
+};
+
+const output = table(data, config);
+console.log(output);
+```
+
+```
+╔═════════════╤═════╤══════════╤═══════╤════════╤══════════════╤═══════════════════╗
+║ -rw-r--r--  │ 1   │ pandorym │ staff │ 1529   │ May 23 11:25 │ LICENSE           ║
+║ -rw-r--r--  │ 1   │ pandorym │ staff │ 16327  │ May 23 11:58 │ README.md         ║
+║ drwxr-xr-x  │ 76  │ pandorym │ staff │ 2432   │ May 23 12:02 │ dist              ║
+║ drwxr-xr-x  │ 634 │ pandorym │ staff │ 20288  │ May 23 11:54 │ node_modules      ║
+║ -rw-r--r--  │ 1,  │ pandorym │ staff │ 525688 │ May 23 11:52 │ package-lock.json ║
+║ -rw-r--r--@ │ 1   │ pandorym │ staff │ 2440   │ May 23 11:25 │ package.json      ║
+║ drwxr-xr-x  │ 27  │ pandorym │ staff │ 864    │ May 23 11:25 │ src               ║
+║ drwxr-xr-x  │ 20  │ pandorym │ staff │ 640    │ May 23 11:25 │ test              ║
+╚═════════════╧═════╧══════════╧═══════╧════════╧══════════════╧═══════════════════╝
 ```
 
 <a name="table-usage-padding-cell-content"></a>

--- a/src/drawTable.js
+++ b/src/drawTable.js
@@ -11,9 +11,10 @@ import drawRow from './drawRow';
  * @param {Array} columnSizeIndex
  * @param {Array} rowSpanIndex
  * @param {Function} drawHorizontalLine
+ * @param {boolean} singleLine
  * @returns {string}
  */
-export default (rows, border, columnSizeIndex, rowSpanIndex, drawHorizontalLine) => {
+export default (rows, border, columnSizeIndex, rowSpanIndex, drawHorizontalLine, singleLine) => {
   let output;
   let realRowIndex;
   let rowHeight;
@@ -39,7 +40,7 @@ export default (rows, border, columnSizeIndex, rowSpanIndex, drawHorizontalLine)
 
     rowHeight--;
 
-    if (rowHeight === 0 && index0 !== rowCount - 1 && drawHorizontalLine(realRowIndex, rowCount)) {
+    if (!singleLine && rowHeight === 0 && index0 !== rowCount - 1 && drawHorizontalLine(realRowIndex, rowCount)) {
       output += drawBorderJoin(columnSizeIndex, border);
     }
   });

--- a/src/makeConfig.js
+++ b/src/makeConfig.js
@@ -68,5 +68,9 @@ export default (rows, userConfig = {}) => {
     };
   }
 
+  if (config.singleLine === undefined) {
+    config.singleLine = false;
+  }
+
   return config;
 };

--- a/src/table.js
+++ b/src/table.js
@@ -63,6 +63,7 @@ import truncateTableData from './truncateTableData';
  * @property {table~columns[]} columns Column specific configuration.
  * @property {table~columns} columnDefault Default values for all columns. Column specific settings overwrite the default values.
  * @property {table~drawHorizontalLine} drawHorizontalLine
+ * @property {table~singleLine} singleLine Horizontal lines inside the table are not drawn.
  */
 
 /**
@@ -91,5 +92,5 @@ export default (data, userConfig = {}) => {
 
   const cellWidthIndex = calculateCellWidthIndex(rows[0]);
 
-  return drawTable(rows, config.border, cellWidthIndex, rowHeightIndex, config.drawHorizontalLine);
+  return drawTable(rows, config.border, cellWidthIndex, rowHeightIndex, config.drawHorizontalLine, config.singleLine);
 };

--- a/test/README/usage/single_line_mode.js
+++ b/test/README/usage/single_line_mode.js
@@ -1,0 +1,42 @@
+import {
+  table
+} from '../../../src';
+import expectTable from './expectTable';
+
+describe('README.md usage/', () => {
+  it('single_line_mode', () => {
+    const data = [
+      ['-rw-r--r--', '1', 'pandorym', 'staff', '1529', 'May 23 11:25', 'LICENSE'],
+      ['-rw-r--r--', '1', 'pandorym', 'staff', '16327', 'May 23 11:58', 'README.md'],
+      ['drwxr-xr-x', '76', 'pandorym', 'staff', '2432', 'May 23 12:02', 'dist'],
+      ['drwxr-xr-x', '634', 'pandorym', 'staff', '20288', 'May 23 11:54', 'node_modules'],
+      ['-rw-r--r--', '1,', 'pandorym', 'staff', '525688', 'May 23 11:52', 'package-lock.json'],
+      ['-rw-r--r--@', '1', 'pandorym', 'staff', '2440', 'May 23 11:25', 'package.json'],
+      ['drwxr-xr-x', '27', 'pandorym', 'staff', '864', 'May 23 11:25', 'src'],
+      ['drwxr-xr-x', '20', 'pandorym', 'staff', '640', 'May 23 11:25', 'test']
+    ];
+
+    const config = {
+      singleLine: true
+    };
+
+    const output = table(data, config);
+
+    // console.log(output);
+
+    /* eslint-disable no-restricted-syntax */
+    expectTable(output, `
+╔═════════════╤═════╤══════════╤═══════╤════════╤══════════════╤═══════════════════╗
+║ -rw-r--r--  │ 1   │ pandorym │ staff │ 1529   │ May 23 11:25 │ LICENSE           ║
+║ -rw-r--r--  │ 1   │ pandorym │ staff │ 16327  │ May 23 11:58 │ README.md         ║
+║ drwxr-xr-x  │ 76  │ pandorym │ staff │ 2432   │ May 23 12:02 │ dist              ║
+║ drwxr-xr-x  │ 634 │ pandorym │ staff │ 20288  │ May 23 11:54 │ node_modules      ║
+║ -rw-r--r--  │ 1,  │ pandorym │ staff │ 525688 │ May 23 11:52 │ package-lock.json ║
+║ -rw-r--r--@ │ 1   │ pandorym │ staff │ 2440   │ May 23 11:25 │ package.json      ║
+║ drwxr-xr-x  │ 27  │ pandorym │ staff │ 864    │ May 23 11:25 │ src               ║
+║ drwxr-xr-x  │ 20  │ pandorym │ staff │ 640    │ May 23 11:25 │ test              ║
+╚═════════════╧═════╧══════════╧═══════╧════════╧══════════════╧═══════════════════╝
+        `);
+    /* eslint-enable no-restricted-syntax */
+  });
+});


### PR DESCRIPTION
In some cases, I want to keep the table compact without drawing horizontal lines in the table.

But if I use `drawHorizontalLine: () = > false`, it makes forms don't draw on the border-top and border-bottom.

Now, with `singleLine: true`:

```
╔═════════════╤═════╤══════════╤═══════╤════════╤══════════════╤═══════════════════╗
║ -rw-r--r--  │ 1   │ pandorym │ staff │ 1529   │ May 23 11:25 │ LICENSE           ║
║ -rw-r--r--  │ 1   │ pandorym │ staff │ 16327  │ May 23 11:58 │ README.md         ║
║ drwxr-xr-x  │ 76  │ pandorym │ staff │ 2432   │ May 23 12:02 │ dist              ║
║ drwxr-xr-x  │ 634 │ pandorym │ staff │ 20288  │ May 23 11:54 │ node_modules      ║
║ -rw-r--r--  │ 1,  │ pandorym │ staff │ 525688 │ May 23 11:52 │ package-lock.json ║
║ -rw-r--r--@ │ 1   │ pandorym │ staff │ 2440   │ May 23 11:25 │ package.json      ║
║ drwxr-xr-x  │ 27  │ pandorym │ staff │ 864    │ May 23 11:25 │ src               ║
║ drwxr-xr-x  │ 20  │ pandorym │ staff │ 640    │ May 23 11:25 │ test              ║
╚═════════════╧═════╧══════════╧═══════╧════════╧══════════════╧═══════════════════╝
```
