### PR TITLE
BREAKING CHANGE: Drop support for NodeJS v6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,7 +15,7 @@
       "@babel/env",
       {
         "targets": {
-          "node": 6
+          "node": 10
         }
       }
     ]

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist
 !.gitignore
 !.npmignore
 !.travis.yml
+
+yarn.lock
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-src
-test
-coverage
-.*
-*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - node
   - 8
-  - 6
+  - 10
+  - 12
 script:
   - export NODE_ENV=test
   - npm run build

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
   },
   "dependencies": {
     "ajv": "^6.10.2",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.15",
     "slice-ansi": "^2.1.0",
-    "string-width": "^3.0.0"
+    "string-width": "^4.1.0"
   },
   "description": "Formats data into a string table.",
   "devDependencies": {
-    "@babel/cli": "^7.5.0",
-    "@babel/core": "^7.5.4",
-    "@babel/node": "^7.5.0",
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/node": "^7.5.5",
     "@babel/plugin-transform-flow-strip-types": "^7.4.4",
-    "@babel/preset-env": "^7.5.4",
-    "@babel/register": "^7.4.4",
+    "@babel/preset-env": "^7.5.5",
+    "@babel/register": "^7.5.5",
     "ajv-cli": "^3.0.0",
     "ajv-keywords": "^3.4.1",
     "babel-plugin-istanbul": "^5.1.4",
@@ -25,19 +25,19 @@
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
     "coveralls": "^3.0.5",
-    "eslint": "^5.13.0",
-    "eslint-config-canonical": "^16.1.0",
-    "flow-bin": "^0.102.0",
+    "eslint": "^6.0.1",
+    "eslint-config-canonical": "^17.1.4",
+    "flow-bin": "^0.103.0",
     "flow-copy-source": "^2.0.7",
     "gitdown": "^3.1.1",
-    "husky": "^3.0.0",
-    "mocha": "^6.1.4",
+    "husky": "^3.0.1",
+    "mocha": "^6.2.0",
     "nyc": "^14.1.1",
     "semantic-release": "^15.13.18",
     "sinon": "^7.3.2"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "husky": {
     "hooks": {
@@ -79,5 +79,8 @@
     "lint": "npm run build && eslint ./src ./test && flow",
     "test": "mocha --require @babel/register"
   },
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "files": [
+    "dist/"
+  ]
 }


### PR DESCRIPTION
NodeJS version 6.0 has been EOL'd since April 30th 2019 and should no longer be fully supported. However introducing such breaking changes should come with a major version upgrade which would mean version 6.0.0. You can view the NodeJS release schedule and history [on NodeJS's GitHub here](https://github.com/nodejs/Release).

This PR officially drops supports for NodeJS v6 and if I understand semantic-release properly the `BREAKING CHANGE:` prefix will trigger a major version upgrade of the packge, to version 6.0.0.

Anyone who will then want to continue using NodeJS v6 (for imho god knows what reason, you're missing out on so much) can lock their installation to v5 with `"table": "^5"` in their `package.json` while everyone else can just use the latest and best supported version with the least risks of security and/or performance issues.

List of changes:

- Upgraded dependencies
- I've adjusted the Travis configuration to test against Node 8 (current maintenance LTS), Node 10 (current LTS) and Node 12 (current Latest).
- Babel configuration is also adjusted to target Node 10.  
- Engines field in package.json got the same treatment, but targeting Node 8.
- I've also removed the `.npmignore` file, instead opting to use the better way of specifying which files to publish in `package.json` using the `files` field. It's far easier to specify which files to publish than to specify which files *not* to publish as the latter falls over the moment you add a new file while the former does not.
- As for the changes to `.gitignore`, I've added `yarn.lock` and `package-lock.json`. I'm going to assume you have your local environment set up to either not generate a lock file or you always remove it pre-commit but for forkers not ignoring lock files when you explicitly do not want them on Git is really frustrating.

Signed-off-by: Jeroen Claassens <support@favware.tech>