### PR TITLE
Optimize lodash imports by using babel-plugin-lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
     }
   },
   "plugins": [
+    "babel-plugin-lodash",
     "transform-export-default-name",
     "@babel/transform-flow-strip-types"
   ],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ajv-cli": "^3.0.0",
     "ajv-keywords": "^3.4.1",
     "babel-plugin-istanbul": "^5.1.4",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-export-default-name": "^2.0.4",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",


### PR DESCRIPTION
This PR optimizes the dist output by adding babel-plugin-lodash which rewrites lodash imports to only import the specific functions used. 

Example:

```javascript
import _ from 'lodash';

_.isString(value);
```

becomes

```javascript
import isString from 'lodash/isString';

isString(value);
```

This allows tools like webpack and rollup to tree-shake this library better without importing the whole lodash js file