### PR TITLE
Stream borderless fix

### DIFF
--- a/src/createStream.js
+++ b/src/createStream.js
@@ -73,13 +73,16 @@ const append = (row, columnWidthIndex, config) => {
     return drawRow(literalRow, config.border);
   }).join('');
 
-  let output;
+  let output = '';
+  let bottom = (0, _drawBorder.drawBorderBottom)(columnWidthIndex, config.border);
 
-  output = '\r\u001B[K';
+  if(bottom !== "\n") {
+    output = '\r\u001B[K';
+  }
 
   output += drawBorderJoin(columnWidthIndex, config.border);
   output += body;
-  output += drawBorderBottom(columnWidthIndex, config.border);
+  output += bottom;
 
   output = _.trimEnd(output);
 

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -74,7 +74,7 @@ const append = (row, columnWidthIndex, config) => {
   }).join('');
 
   let output = '';
-  let bottom = (0, _drawBorder.drawBorderBottom)(columnWidthIndex, config.border);
+  let bottom = drawBorderBottom(columnWidthIndex, config.border);
 
   if(bottom !== "\n") {
     output = '\r\u001B[K';

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -74,9 +74,9 @@ const append = (row, columnWidthIndex, config) => {
   }).join('');
 
   let output = '';
-  let bottom = drawBorderBottom(columnWidthIndex, config.border);
+  const bottom = drawBorderBottom(columnWidthIndex, config.border);
 
-  if(bottom !== "\n") {
+  if (bottom !== '\n') {
     output = '\r\u001B[K';
   }
 


### PR DESCRIPTION
### Current situation 
If data gets streamed to stdout and no border is configured (`void`), only the last
line of the data gets written to stdout.

### Should
If no border is configured the current line must not be cleared.

### Reproduce
```js
const createStream = require('table').createStream;
const getBorderCharacters = require('table').getBorderCharacters;

let config,
  stream;

config = {
  border: getBorderCharacters('void'), //no problem using ramac for example.
  columnDefault: {
    width: 50
  },
  columnCount: 1
};

stream = createStream(config);

setInterval(() => {
  stream.write([new Date()]);
}, 500);
```