### PR TITLE
do not draw new line on the top (borderless)

### DIFF
--- a/src/drawBorder.js
+++ b/src/drawBorder.js
@@ -35,12 +35,18 @@ const drawBorder = (columnSizeIndex, parts) => {
  * @returns {string}
  */
 const drawBorderTop = (columnSizeIndex, parts) => {
-  return drawBorder(columnSizeIndex, {
+  let border = drawBorder(columnSizeIndex, {
     body: parts.topBody,
     join: parts.topJoin,
     left: parts.topLeft,
     right: parts.topRight
   });
+
+  if(border === "\n") {
+    return "";
+  }
+
+  return border;
 };
 
 /**

--- a/src/drawBorder.js
+++ b/src/drawBorder.js
@@ -35,15 +35,15 @@ const drawBorder = (columnSizeIndex, parts) => {
  * @returns {string}
  */
 const drawBorderTop = (columnSizeIndex, parts) => {
-  let border = drawBorder(columnSizeIndex, {
+  const border = drawBorder(columnSizeIndex, {
     body: parts.topBody,
     join: parts.topJoin,
     left: parts.topLeft,
     right: parts.topRight
   });
 
-  if(border === "\n") {
-    return "";
+  if (border === '\n') {
+    return '';
   }
 
   return border;

--- a/test/drawBorder.js
+++ b/test/drawBorder.js
@@ -38,6 +38,19 @@ describe('drawBorderTop', () => {
     expect(drawBorderTop([1, 1], parts)).to.equal('╔═╤═╗\n');
     expect(drawBorderTop([5, 10], parts)).to.equal('╔═════╤══════════╗\n');
   });
+
+  it('no leading new line if borderless', () => {
+    const parts = {
+      topLeft: '',
+      topRight: '',
+      topBody: '',
+      topJoin: ''
+    };
+
+    expect(drawBorderTop([1], parts)).to.equal('');
+    expect(drawBorderTop([1, 1], parts)).to.equal('');
+    expect(drawBorderTop([5, 10], parts)).to.equal('');
+  });
 });
 
 describe('drawBorderJoin', () => {


### PR DESCRIPTION
### Current situation 
If data gets streamed to stdout and no border is configured (`void`), a leading new line
gets written to stdout at the beginning.

### Should
With no borders there shouldn't be a new line on the top.

### Reproduce
```js
const createStream = require('table').createStream;
const getBorderCharacters = require('table').getBorderCharacters;

let config,
  stream;

config = {
  border: getBorderCharacters('void'), //no problem using ramac for example.
  columnDefault: {
    width: 50
  },
  columnCount: 1
};

stream = createStream(config);

setInterval(() => {
  stream.write([new Date()]);
}, 500);
```