### PR TITLE
Destructuring ES6 Module default export => not possible anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ npm install table
 Table data is described using an array (rows) of array (cells).
 
 ```js
-import {
-  table
-} from 'table';
+import tableImport from 'table';
+const { table } = tableImport;
 
 // Using commonjs?
 // const {table} = require('table');


### PR DESCRIPTION
https://github.com/babel/babel/issues/3049

https://stackoverflow.com/a/33524809

"With Babel 5 and below I believe they have been interchangeable because of the way ES6 modules have been transpiled to CommonJS. But those are two different constructs as far as the language goes."

"Babel 6 does not make the two interchangable. Beware!"

In node.js with `type: "module"` it also does not work because it's not standard. ..