### PR TITLE
chore(deps): bump lodash to 4.17.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "ajv": "^6.10.2",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.19",
     "slice-ansi": "^2.1.0",
     "string-width": "^3.0.0"
   },


### PR DESCRIPTION
There currently is an NPM advisory prompting to upgrade Lodash to 4.17.19 or later : https://www.npmjs.com/advisories/1523