### PR TITLE
fix: alignCenter (#115)

### DIFF
--- a/src/alignString.js
+++ b/src/alignString.js
@@ -35,7 +35,7 @@ const alignCenter = (subject, width) => {
 
   halfWidth = width / 2;
 
-  if (halfWidth % 2 === 0) {
+  if (width % 2 === 0) {
     return ' '.repeat(halfWidth) + subject + ' '.repeat(halfWidth);
   } else {
     halfWidth = Math.floor(halfWidth);

--- a/test/alignString.js
+++ b/test/alignString.js
@@ -64,7 +64,7 @@ describe('alignString', () => {
         });
         context('center', () => {
           it('pads the string on both sides using a whitespace character', () => {
-            expect(alignString('aa', 6, 'center')).to.equal('  aa  ');
+            expect(alignString('aa', 8, 'center')).to.equal('   aa   ');
           });
           context('uneven number of available with', () => {
             it('floors the available width; adds extra space to the end of the string', () => {


### PR DESCRIPTION
The method for alignCenter is checking
to see if halfWidth (rather than width)
is even. This worked with the existing test
case because the container width given is 6
minus string width (2) is 4. Divide that in half
and you have an even number.

My test case makes the container width 8.
So available width is 6. Divide that in half
you get an odd number. So the odd logic triggers
padding 3 to the left and 4 to the right.

This commit fixes the minor defect.

Fixes #115