### PR TITLE
Add option to disable wrapping text

### DIFF
--- a/src/alignString.js
+++ b/src/alignString.js
@@ -53,7 +53,7 @@ const alignCenter = (subject, width) => {
  * @param {string} alignment One of the valid options (left, right, center).
  * @returns {string}
  */
-export default (subject, containerWidth, alignment) => {
+export default (subject, containerWidth, alignment, disableWrap) => {
   if (!_.isString(subject)) {
     throw new TypeError('Subject parameter value must be a string.');
   }
@@ -64,7 +64,7 @@ export default (subject, containerWidth, alignment) => {
 
   const subjectWidth = stringWidth(subject);
 
-  if (subjectWidth > containerWidth) {
+  if (!disableWrap && subjectWidth > containerWidth) {
     // console.log('subjectWidth', subjectWidth, 'containerWidth', containerWidth, 'subject', subject);
 
     throw new Error('Subject parameter value width cannot be greater than the container width.');
@@ -82,7 +82,7 @@ export default (subject, containerWidth, alignment) => {
     return ' '.repeat(containerWidth);
   }
 
-  const availableWidth = containerWidth - subjectWidth;
+  const availableWidth = Math.max(containerWidth - subjectWidth, 0);
 
   if (alignment === 'left') {
     return alignLeft(subject, availableWidth);

--- a/src/alignTableData.js
+++ b/src/alignTableData.js
@@ -14,7 +14,7 @@ export default (rows, config) => {
       if (stringWidth(value) === column.width) {
         return value;
       } else {
-        return alignString(value, column.width, column.alignment);
+        return alignString(value, column.width, column.alignment, column.disableWrap);
       }
     });
   });

--- a/src/calculateCellHeight.js
+++ b/src/calculateCellHeight.js
@@ -5,9 +5,10 @@ import wrapCell from './wrapCell';
  * @param {string} value
  * @param {number} columnWidth
  * @param {boolean} useWrapWord
+ * @param {boolean} disableWrap
  * @returns {number}
  */
-export default (value, columnWidth, useWrapWord = false) => {
+export default (value, columnWidth, useWrapWord = false, disableWrap = false) => {
   if (!_.isString(value)) {
     throw new TypeError('Value must be a string.');
   }
@@ -20,5 +21,5 @@ export default (value, columnWidth, useWrapWord = false) => {
     throw new Error('Column width must be greater than 0.');
   }
 
-  return wrapCell(value, columnWidth, useWrapWord).length;
+  return wrapCell(value, columnWidth, useWrapWord, disableWrap).length;
 };

--- a/src/calculateRowHeightIndex.js
+++ b/src/calculateRowHeightIndex.js
@@ -32,7 +32,7 @@ export default (rows, config) => {
         value,
         config.columns[index1].width,
         config.columns[index1].wrapWord,
-        config.columns[index1].disableWrap
+        config.columns[index1].disableWrap,
       );
     });
 

--- a/src/calculateRowHeightIndex.js
+++ b/src/calculateRowHeightIndex.js
@@ -24,8 +24,16 @@ export default (rows, config) => {
       if (!_.isBoolean(config.columns[index1].wrapWord)) {
         throw new TypeError('column[index].wrapWord must be a boolean.');
       }
+      if (!_.isBoolean(config.columns[index1].disableWrap)) {
+        throw new TypeError('column[index].disableWrap must be a boolean.');
+      }
 
-      cellHeightIndex[index1] = calculateCellHeight(value, config.columns[index1].width, config.columns[index1].wrapWord);
+      cellHeightIndex[index1] = calculateCellHeight(
+        value,
+        config.columns[index1].width,
+        config.columns[index1].wrapWord,
+        config.columns[index1].disableWrap
+      );
     });
 
     rowSpanIndex.push(_.max(cellHeightIndex));

--- a/src/makeConfig.js
+++ b/src/makeConfig.js
@@ -37,6 +37,7 @@ const makeColumns = (rows, columns = {}, columnDefault = {}) => {
       truncate: Number.POSITIVE_INFINITY,
       width: maximumColumnWidthIndex[index],
       wrapWord: false,
+      disableWrap: false
     }, columnDefault, columns[index]);
   });
 

--- a/src/makeConfig.js
+++ b/src/makeConfig.js
@@ -32,12 +32,12 @@ const makeColumns = (rows, columns = {}, columnDefault = {}) => {
 
     columns[index] = Object.assign({
       alignment: 'left',
+      disableWrap: false,
       paddingLeft: 1,
       paddingRight: 1,
       truncate: Number.POSITIVE_INFINITY,
       width: maximumColumnWidthIndex[index],
       wrapWord: false,
-      disableWrap: false
     }, columnDefault, columns[index]);
   });
 

--- a/src/makeStreamConfig.js
+++ b/src/makeStreamConfig.js
@@ -33,6 +33,7 @@ const makeColumns = (columnCount, columns = {}, columnDefault = {}) => {
       paddingRight: 1,
       truncate: Number.POSITIVE_INFINITY,
       wrapWord: false,
+      disableWrap: false
     }, columnDefault, columns[index]);
   });
 

--- a/src/makeStreamConfig.js
+++ b/src/makeStreamConfig.js
@@ -29,11 +29,11 @@ const makeColumns = (columnCount, columns = {}, columnDefault = {}) => {
 
     columns[index] = Object.assign({
       alignment: 'left',
+      disableWrap: false,
       paddingLeft: 1,
       paddingRight: 1,
       truncate: Number.POSITIVE_INFINITY,
       wrapWord: false,
-      disableWrap: false
     }, columnDefault, columns[index]);
   });
 

--- a/src/mapDataUsingRowHeightIndex.js
+++ b/src/mapDataUsingRowHeightIndex.js
@@ -20,7 +20,12 @@ export default (unmappedRows, rowHeightIndex, config) => {
     //     [{cell index within a virtual row; index1}]
 
     cells.forEach((value, index1) => {
-      const cellLines = wrapCell(value, config.columns[index1].width, config.columns[index1].wrapWord);
+      const cellLines = wrapCell(
+        value,
+        config.columns[index1].width,
+        config.columns[index1].wrapWord,
+        config.columns[index1].disableWrap
+      );
 
       cellLines.forEach((cellLine, index2) => {
         rowHeight[index2][index1] = cellLine;

--- a/src/mapDataUsingRowHeightIndex.js
+++ b/src/mapDataUsingRowHeightIndex.js
@@ -24,7 +24,7 @@ export default (unmappedRows, rowHeightIndex, config) => {
         value,
         config.columns[index1].width,
         config.columns[index1].wrapWord,
-        config.columns[index1].disableWrap
+        config.columns[index1].disableWrap,
       );
 
       cellLines.forEach((cellLine, index2) => {

--- a/src/table.js
+++ b/src/table.js
@@ -23,6 +23,7 @@ import validateTableData from './validateTableData';
  * @property {number} width Column width (default: auto).
  * @property {number} truncate Number of characters are which the content will be truncated (default: Infinity).
  * @property {boolean} wrapWord When true the text is broken at the nearest space or one of the special characters
+ * @property {boolean} disableWrap When true the text will not wrap based on width
  * @property {number} paddingLeft Cell content padding width left (default: 1).
  * @property {number} paddingRight Cell content padding width right (default: 1).
  */

--- a/src/wrapCell.js
+++ b/src/wrapCell.js
@@ -10,11 +10,17 @@ import wrapWord from './wrapWord';
  * @param {string} cellValue
  * @param {number} columnWidth
  * @param {boolean} useWrapWord
+ * @param {boolean} disableWrap
  * @returns {Array}
  */
-export default (cellValue, columnWidth, useWrapWord) => {
+export default (cellValue, columnWidth, useWrapWord, disableWrap) => {
   // First split on literal newlines
   const cellLines = cellValue.split('\n');
+
+  // early exit if wrapping of words is disabled
+  if (disableWrap) {
+    return cellLines;
+  }
 
   // Then iterate over the list and word-wrap every remaining line if necessary.
   for (let lineNr = 0; lineNr < cellLines.length;) {

--- a/test/calculateRowHeightIndex.js
+++ b/test/calculateRowHeightIndex.js
@@ -4,6 +4,7 @@ import {
   expect,
 } from 'chai';
 import calculateRowHeightIndex from '../src/calculateRowHeightIndex';
+import makeConfig from '../src/makeConfig';
 
 describe('calculateRowHeightIndex', () => {
   context('single column', () => {
@@ -15,14 +16,14 @@ describe('calculateRowHeightIndex', () => {
           ],
         ];
 
-        const config = {
+        const config = makeConfig(data, {
           columns: {
             0: {
               width: 10,
               wrapWord: false,
             },
           },
-        };
+        });
 
         const rowSpanIndex = calculateRowHeightIndex(data, config);
 
@@ -37,14 +38,14 @@ describe('calculateRowHeightIndex', () => {
           ],
         ];
 
-        const config = {
+        const config = makeConfig(data, {
           columns: {
             0: {
               width: 3,
               wrapWord: false,
             },
           },
-        };
+        });
 
         const rowSpanIndex = calculateRowHeightIndex(data, config);
 
@@ -60,14 +61,14 @@ describe('calculateRowHeightIndex', () => {
           ['aaabbb'],
         ];
 
-        const config = {
+        const config = makeConfig(data, {
           columns: {
             0: {
               width: 2,
               wrapWord: false,
             },
           },
-        };
+        });
 
         const rowSpanIndex = calculateRowHeightIndex(data, config);
 


### PR DESCRIPTION
When width is set, cell text is always wrapped. In some cases this is
undesirable. For example adding formatting that will shrink the effective
size of the cell. see gajus/table#117


This is a quick and dirty PR to get started on this feature.
Obviously tests and docs are needed, just wanted to get feedback before going further.

`disableWrap` is a boolean option on columns that allows bypassing the text wrap functions altogether.