### PR TITLE
Use lodash method imports & replace some with native functions

### DIFF
--- a/src/alignString.js
+++ b/src/alignString.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import isNumber from 'lodash/isNumber';
+import isString from 'lodash/isString';
 import stringWidth from 'string-width';
 
 const alignments = [
@@ -54,11 +55,11 @@ const alignCenter = (subject, width) => {
  * @returns {string}
  */
 export default (subject, containerWidth, alignment) => {
-  if (!_.isString(subject)) {
+  if (!isString(subject)) {
     throw new TypeError('Subject parameter value must be a string.');
   }
 
-  if (!_.isNumber(containerWidth)) {
+  if (!isNumber(containerWidth)) {
     throw new TypeError('Container width parameter value must be a number.');
   }
 
@@ -70,7 +71,7 @@ export default (subject, containerWidth, alignment) => {
     throw new Error('Subject parameter value width cannot be greater than the container width.');
   }
 
-  if (!_.isString(alignment)) {
+  if (!isString(alignment)) {
     throw new TypeError('Alignment parameter value must be a string.');
   }
 

--- a/src/calculateCellHeight.js
+++ b/src/calculateCellHeight.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isString from 'lodash/isString';
 import wrapCell from './wrapCell';
 
 /**
@@ -8,7 +8,7 @@ import wrapCell from './wrapCell';
  * @returns {number}
  */
 export default (value, columnWidth, useWrapWord = false) => {
-  if (!_.isString(value)) {
+  if (!isString(value)) {
     throw new TypeError('Value must be a string.');
   }
 

--- a/src/calculateRowHeightIndex.js
+++ b/src/calculateRowHeightIndex.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import isBoolean from 'lodash/isBoolean';
+import isNumber from 'lodash/isNumber';
+import max from 'lodash/max';
 import calculateCellHeight from './calculateCellHeight';
 
 /**
@@ -17,18 +19,18 @@ export default (rows, config) => {
     const cellHeightIndex = new Array(tableWidth).fill(1);
 
     cells.forEach((value, index1) => {
-      if (!_.isNumber(config.columns[index1].width)) {
+      if (!isNumber(config.columns[index1].width)) {
         throw new TypeError('column[index].width must be a number.');
       }
 
-      if (!_.isBoolean(config.columns[index1].wrapWord)) {
+      if (!isBoolean(config.columns[index1].wrapWord)) {
         throw new TypeError('column[index].wrapWord must be a boolean.');
       }
 
       cellHeightIndex[index1] = calculateCellHeight(value, config.columns[index1].width, config.columns[index1].wrapWord);
     });
 
-    rowSpanIndex.push(_.max(cellHeightIndex));
+    rowSpanIndex.push(max(cellHeightIndex));
   });
 
   return rowSpanIndex;

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -1,5 +1,4 @@
 import mapValues from 'lodash/mapValues';
-import trimEnd from 'lodash/trimEnd';
 import values from 'lodash/values';
 import alignTableData from './alignTableData';
 import calculateRowHeightIndex from './calculateRowHeightIndex';
@@ -57,7 +56,7 @@ const create = (row, columnWidthIndex, config) => {
   output += body;
   output += drawBorderBottom(columnWidthIndex, config.border);
 
-  output = trimEnd(output);
+  output = output.trimEnd();
 
   process.stdout.write(output);
 };
@@ -86,7 +85,7 @@ const append = (row, columnWidthIndex, config) => {
   output += body;
   output += bottom;
 
-  output = trimEnd(output);
+  output = output.trimEnd();
 
   process.stdout.write(output);
 };

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -1,5 +1,4 @@
 import mapValues from 'lodash/mapValues';
-import values from 'lodash/values';
 import alignTableData from './alignTableData';
 import calculateRowHeightIndex from './calculateRowHeightIndex';
 import {
@@ -97,8 +96,7 @@ const append = (row, columnWidthIndex, config) => {
 export default (userConfig = {}) => {
   const config = makeStreamConfig(userConfig);
 
-  // @todo Use 'Object.values' when Node.js v6 support is dropped.
-  const columnWidthIndex = values(mapValues(config.columns, (column) => {
+  const columnWidthIndex = Object.values(mapValues(config.columns, (column) => {
     return column.width + column.paddingLeft + column.paddingRight;
   }));
 

--- a/src/createStream.js
+++ b/src/createStream.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import mapValues from 'lodash/mapValues';
+import trimEnd from 'lodash/trimEnd';
+import values from 'lodash/values';
 import alignTableData from './alignTableData';
 import calculateRowHeightIndex from './calculateRowHeightIndex';
 import {
@@ -55,7 +57,7 @@ const create = (row, columnWidthIndex, config) => {
   output += body;
   output += drawBorderBottom(columnWidthIndex, config.border);
 
-  output = _.trimEnd(output);
+  output = trimEnd(output);
 
   process.stdout.write(output);
 };
@@ -84,7 +86,7 @@ const append = (row, columnWidthIndex, config) => {
   output += body;
   output += bottom;
 
-  output = _.trimEnd(output);
+  output = trimEnd(output);
 
   process.stdout.write(output);
 };
@@ -97,7 +99,7 @@ export default (userConfig = {}) => {
   const config = makeStreamConfig(userConfig);
 
   // @todo Use 'Object.values' when Node.js v6 support is dropped.
-  const columnWidthIndex = _.values(_.mapValues(config.columns, (column) => {
+  const columnWidthIndex = values(mapValues(config.columns, (column) => {
     return column.width + column.paddingLeft + column.paddingRight;
   }));
 

--- a/src/makeConfig.js
+++ b/src/makeConfig.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isUndefined from 'lodash/isUndefined';
+import times from 'lodash/times';
 import calculateMaximumColumnWidthIndex from './calculateMaximumColumnWidthIndex';
 import getBorderCharacters from './getBorderCharacters';
 import validateConfig from './validateConfig';
@@ -25,8 +27,8 @@ const makeBorder = (border = {}) => {
 const makeColumns = (rows, columns = {}, columnDefault = {}) => {
   const maximumColumnWidthIndex = calculateMaximumColumnWidthIndex(rows);
 
-  _.times(rows[0].length, (index) => {
-    if (_.isUndefined(columns[index])) {
+  times(rows[0].length, (index) => {
+    if (isUndefined(columns[index])) {
       columns[index] = {};
     }
 
@@ -54,7 +56,7 @@ const makeColumns = (rows, columns = {}, columnDefault = {}) => {
 export default (rows, userConfig = {}) => {
   validateConfig('config.json', userConfig);
 
-  const config = _.cloneDeep(userConfig);
+  const config = cloneDeep(userConfig);
 
   config.border = makeBorder(config.border);
   config.columns = makeColumns(rows, config.columns, config.columnDefault);

--- a/src/makeStreamConfig.js
+++ b/src/makeStreamConfig.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isUndefined from 'lodash/isUndefined';
+import times from 'lodash/times';
 import getBorderCharacters from './getBorderCharacters';
 import validateConfig from './validateConfig';
 
@@ -22,8 +24,8 @@ const makeBorder = (border = {}) => {
  * @returns {object}
  */
 const makeColumns = (columnCount, columns = {}, columnDefault = {}) => {
-  _.times(columnCount, (index) => {
-    if (_.isUndefined(columns[index])) {
+  times(columnCount, (index) => {
+    if (isUndefined(columns[index])) {
       columns[index] = {};
     }
 
@@ -66,7 +68,7 @@ const makeColumns = (columnCount, columns = {}, columnDefault = {}) => {
 export default (userConfig = {}) => {
   validateConfig('streamConfig.json', userConfig);
 
-  const config = _.cloneDeep(userConfig);
+  const config = cloneDeep(userConfig);
 
   if (!config.columnDefault || !config.columnDefault.width) {
     throw new Error('Must provide config.columnDefault.width when creating a stream.');

--- a/src/mapDataUsingRowHeightIndex.js
+++ b/src/mapDataUsingRowHeightIndex.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import flatten from 'lodash/flatten';
+import times from 'lodash/times';
 import wrapCell from './wrapCell';
 
 /**
@@ -11,7 +12,7 @@ export default (unmappedRows, rowHeightIndex, config) => {
   const tableWidth = unmappedRows[0].length;
 
   const mappedRows = unmappedRows.map((cells, index0) => {
-    const rowHeight = _.times(rowHeightIndex[index0], () => {
+    const rowHeight = times(rowHeightIndex[index0], () => {
       return new Array(tableWidth).fill('');
     });
 
@@ -30,5 +31,5 @@ export default (unmappedRows, rowHeightIndex, config) => {
     return rowHeight;
   });
 
-  return _.flatten(mappedRows);
+  return flatten(mappedRows);
 };

--- a/src/truncateTableData.js
+++ b/src/truncateTableData.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 
 /**
  * @todo Make it work with ASCII content.
@@ -9,7 +9,7 @@ import _ from 'lodash';
 export default (rows, config) => {
   return rows.map((cells) => {
     return cells.map((content, index) => {
-      return _.truncate(content, {
+      return truncate(content, {
         length: config.columns[index].truncate,
       });
     });


### PR DESCRIPTION
I know there's been some recent bad experience with lodash refactors but I hope this more conservative approach here is safer.

The PR does 2 things:

- It uses the lodash per method imports. This loads less code but more importantly it makes it easier to see what parts of lodash are actually used by `table`
- It uses the native functions `String.prototype.trimEnd` and `Object.values`. Both are available now that `table` requires Node.js 10

Some other things might be possible but I think they're better kept for follow-up PRs.

Note I did not use the per-method packages as they're [deprecated](https://lodash.com/per-method-packages) and actually hurt deduplication. They also load more code than this approach.