### PR TITLE
Configure babel to generate code for Node.js 10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,7 @@
       "@babel/env",
       {
         "targets": {
-          "node": 6
+          "node": 10
         }
       }
     ]


### PR DESCRIPTION
Since table now requires Node.js 10 this will generate code to that target. The only difference I could find in the output is that `for of` is no longer transpiled.