### PR TITLE
RFC: Build using rollup.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,8 +8,7 @@
   },
   "plugins": [
     "babel-plugin-lodash",
-    "transform-export-default-name",
-    "@babel/transform-flow-strip-types"
+    "transform-export-default-name"
   ],
   "presets": [
     [

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 node_modules
 coverage
 dist
+src/compiled_schema
 *.log
 .*
+package-lock.json
 !.editorconfig
 !.babelrc
 !.eslintrc

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 coverage
 .*
 *.log
+rollup.config.js

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "description": "Formats data into a string table.",
   "devDependencies": {
-    "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.4",
-    "@babel/node": "^7.10.5",
-    "@babel/plugin-transform-flow-strip-types": "^7.10.4",
     "@babel/preset-env": "^7.11.0",
     "@babel/register": "^7.10.5",
+    "@rollup/plugin-babel": "^5.2.1",
+    "@rollup/plugin-commonjs": "^16.0.0",
+    "@rollup/plugin-node-resolve": "^10.0.0",
     "ajv-cli": "^3.2.1",
     "ajv-keywords": "^3.5.2",
     "babel-plugin-istanbul": "^6.0.0",
@@ -29,11 +29,12 @@
     "eslint": "^7.7.0",
     "eslint-config-canonical": "^23.0.1",
     "flow-bin": "^0.132.0",
-    "flow-copy-source": "^2.0.9",
     "gitdown": "^3.1.3",
     "husky": "^4.2.5",
+    "mkdirp": "^1.0.4",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
+    "rollup": "^2.33.3",
     "semantic-release": "^17.1.1",
     "sinon": "^9.0.3"
   },
@@ -74,10 +75,10 @@
     "url": "https://github.com/gajus/table"
   },
   "scripts": {
-    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps && npm run create-validators && flow-copy-source src dist",
+    "build": "rm -fr ./dist && mkdirp ./dist && npm run create-validators && rollup -c",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md",
-    "create-validators": "ajv compile --all-errors --inline-refs=false -s src/schemas/config -c ajv-keywords/keywords/typeof -o dist/validateConfig.js && ajv compile --all-errors --inline-refs=false -s src/schemas/streamConfig -c ajv-keywords/keywords/typeof -o dist/validateStreamConfig.js",
-    "lint": "npm run build && eslint ./src ./test && flow",
+    "create-validators": "rm -fr ./src/compiled_schema && mkdirp ./src/compiled_schema && ajv compile --all-errors --inline-refs=false -s src/schemas/config -c ajv-keywords/keywords/typeof -o src/compiled_schema/validateConfig.js && ajv compile --all-errors --inline-refs=false -s src/schemas/streamConfig -c ajv-keywords/keywords/typeof -o src/compiled_schema/validateStreamConfig.js",
+    "lint": "npm run build && eslint --ignore-path .gitignore && flow",
     "test": "mocha --require @babel/register"
   },
   "version": "1.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,33 @@
+import babel from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import pkg from './package.json';
+
+const dependencies = Object.keys(pkg.dependencies);
+
+export default [
+  {
+    input: 'src/index.js',
+    external: (id) => {
+        if (dependencies.includes(id)) {
+          return true;
+        }
+
+        return id.startsWith('lodash') || id.startsWith('ajv');
+    },
+    output: [
+      {
+        file: pkg.main,
+        format: 'cjs',
+      },
+    ],
+    plugins: [
+      commonjs(),
+      nodeResolve(),
+      babel({
+        babelHelpers: 'bundled',
+        exclude: ['node_modules/**'],
+      })
+    ],
+  }
+];

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/default
-import validateConfig from '../dist/validateConfig';
+import validateConfig from './compiled_schema/validateConfig';
 // eslint-disable-next-line import/default
-import validateStreamConfig from '../dist/validateStreamConfig';
+import validateStreamConfig from './compiled_schema/validateStreamConfig';
 
 const validate = {
   'config.json': validateConfig,

--- a/test/config.js
+++ b/test/config.js
@@ -3,7 +3,7 @@ import ajvKeywords from 'ajv-keywords';
 import {
   expect,
 } from 'chai';
-import validateConfig from '../dist/validateConfig';
+import validateConfig from '../src/compiled_schema/validateConfig';
 import configSchema from '../src/schemas/config.json';
 import configSamples from './configSamples';
 

--- a/test/streamConfig.js
+++ b/test/streamConfig.js
@@ -4,7 +4,7 @@ import ajvSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
 import {
   expect,
 } from 'chai';
-import validateConfig from '../dist/validateStreamConfig';
+import validateConfig from '../src/compiled_schema/validateStreamConfig';
 import configSchema from '../src/schemas/streamConfig.json';
 import configSamples from './streamConfigSamples';
 


### PR DESCRIPTION
This PR uses rollup.js to bundle all `table` into a single (CommonJS) JavaScript file.

This has a few small advantages:

- Less code is shipped (size on disk for the package is 94 KB vs 393 KB - ~76% less)
- Less require time (only one file is loaded)
- Code deduplicated (e.g. `_interopDefaultLegacy` exists only once, instead of once per file)
- Eventually it'll be very easy to ship both an ESM and a CJS version if desired

More excitingly, it would open a path to making `ajv` a pure dev dependency with an approach like this one: 0d3fe98b83d0da15d9ae09ccd3851f9e30f78db9 (I didn't make it part of this PR as I think it warrants its own review).

There's two things I changed that I'm not sure of:

- [ ] I left the flow types as comments intact in the main file. I don't know enough about flow to know if those are being read or if it needs a 2nd file with the extensions `.flow`
- [ ] I removed the generation of source maps as I don't think the serve a useful purpose. The code of the one big file is quite easy to use for debugging as it's not mangled at all.

Both can easily be changed if desired.

This is quite an invasive change to how `table` is bundled so I fully understand if you don't wanna go down this path. Let me know what you think.
