### PR TITLE
migrate to ajv v7 [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "ajv": "^6.12.4",
+    "ajv": "^7.0.0-rc.0",
     "lodash": "^4.17.20",
     "slice-ansi": "^4.0.0",
     "string-width": "^4.2.0"
@@ -18,8 +18,8 @@
     "@babel/plugin-transform-flow-strip-types": "^7.10.4",
     "@babel/preset-env": "^7.11.0",
     "@babel/register": "^7.10.5",
-    "ajv-cli": "^3.2.1",
-    "ajv-keywords": "^3.5.2",
+    "ajv-cli": "^4.0.0-rc.0",
+    "ajv-keywords": "^4.0.0-beta.3",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-export-default-name": "^2.0.4",
@@ -32,6 +32,7 @@
     "flow-copy-source": "^2.0.9",
     "gitdown": "^3.1.3",
     "husky": "^4.2.5",
+    "js-beautify": "^1.13.0",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "semantic-release": "^17.1.1",
@@ -76,7 +77,7 @@
   "scripts": {
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps && npm run create-validators && flow-copy-source src dist",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md",
-    "create-validators": "ajv compile --all-errors --inline-refs=false -s src/schemas/config -c ajv-keywords/keywords/typeof -o dist/validateConfig.js && ajv compile --all-errors --inline-refs=false -s src/schemas/streamConfig -c ajv-keywords/keywords/typeof -o dist/validateStreamConfig.js",
+    "create-validators": "ajv compile --all-errors --inline-refs=false -s src/schemas/config -s src/schemas/streamConfig -r src/schemas/shared -c ajv-keywords/dist/keywords/typeof -o | js-beautify > dist/validators.js",
     "lint": "npm run build && eslint ./src ./test && flow",
     "test": "mocha --require @babel/register"
   },

--- a/src/schemas/config.json
+++ b/src/schemas/config.json
@@ -4,111 +4,17 @@
     "type": "object",
     "properties": {
         "border": {
-            "$ref": "#/definitions/borders"
+            "$ref": "shared.json#/definitions/borders"
         },
         "columns": {
-            "$ref": "#/definitions/columns"
+            "$ref": "shared.json#/definitions/columns"
         },
         "columnDefault": {
-            "$ref": "#/definitions/column"
+            "$ref": "shared.json#/definitions/column"
         },
         "drawHorizontalLine": {
             "typeof": "function"
         }
     },
-    "additionalProperties": false,
-    "definitions": {
-        "columns": {
-            "type": "object",
-            "patternProperties": {
-                "^[0-9]+$": {
-                    "$ref": "#/definitions/column"
-                }
-            },
-            "additionalProperties": false
-        },
-        "column": {
-            "type": "object",
-            "properties": {
-                "alignment": {
-                    "type": "string",
-                    "enum": [
-                        "left",
-                        "right",
-                        "center"
-                    ]
-                },
-                "width": {
-                    "type": "number"
-                },
-                "wrapWord": {
-                    "type": "boolean"
-                },
-                "truncate": {
-                    "type": "number"
-                },
-                "paddingLeft": {
-                    "type": "number"
-                },
-                "paddingRight": {
-                    "type": "number"
-                }
-            },
-            "additionalProperties": false
-        },
-        "borders": {
-            "type": "object",
-            "properties": {
-                "topBody": {
-                    "$ref": "#/definitions/border"
-                },
-                "topJoin": {
-                    "$ref": "#/definitions/border"
-                },
-                "topLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "topRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomBody": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomJoin": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "bodyLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "bodyRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "bodyJoin": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinBody": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinJoin": {
-                    "$ref": "#/definitions/border"
-                }
-            },
-            "additionalProperties": false
-        },
-        "border": {
-            "type": "string"
-        }
-    }
+    "additionalProperties": false
 }

--- a/src/schemas/shared.json
+++ b/src/schemas/shared.json
@@ -1,0 +1,98 @@
+{
+    "$id": "shared.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "columns": {
+            "type": "object",
+            "patternProperties": {
+                "^[0-9]+$": {
+                    "$ref": "#/definitions/column"
+                }
+            },
+            "additionalProperties": false
+        },
+        "column": {
+            "type": "object",
+            "properties": {
+                "alignment": {
+                    "type": "string",
+                    "enum": [
+                        "left",
+                        "right",
+                        "center"
+                    ]
+                },
+                "width": {
+                    "type": "number"
+                },
+                "wrapWord": {
+                    "type": "boolean"
+                },
+                "truncate": {
+                    "type": "number"
+                },
+                "paddingLeft": {
+                    "type": "number"
+                },
+                "paddingRight": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false
+        },
+        "borders": {
+            "type": "object",
+            "properties": {
+                "topBody": {
+                    "$ref": "#/definitions/border"
+                },
+                "topJoin": {
+                    "$ref": "#/definitions/border"
+                },
+                "topLeft": {
+                    "$ref": "#/definitions/border"
+                },
+                "topRight": {
+                    "$ref": "#/definitions/border"
+                },
+                "bottomBody": {
+                    "$ref": "#/definitions/border"
+                },
+                "bottomJoin": {
+                    "$ref": "#/definitions/border"
+                },
+                "bottomLeft": {
+                    "$ref": "#/definitions/border"
+                },
+                "bottomRight": {
+                    "$ref": "#/definitions/border"
+                },
+                "bodyLeft": {
+                    "$ref": "#/definitions/border"
+                },
+                "bodyRight": {
+                    "$ref": "#/definitions/border"
+                },
+                "bodyJoin": {
+                    "$ref": "#/definitions/border"
+                },
+                "joinBody": {
+                    "$ref": "#/definitions/border"
+                },
+                "joinLeft": {
+                    "$ref": "#/definitions/border"
+                },
+                "joinRight": {
+                    "$ref": "#/definitions/border"
+                },
+                "joinJoin": {
+                    "$ref": "#/definitions/border"
+                }
+            },
+            "additionalProperties": false
+        },
+        "border": {
+            "type": "string"
+        }
+    }
+}

--- a/src/schemas/streamConfig.json
+++ b/src/schemas/streamConfig.json
@@ -4,111 +4,17 @@
     "type": "object",
     "properties": {
         "border": {
-            "$ref": "#/definitions/borders"
+            "$ref": "shared.json#/definitions/borders"
         },
         "columns": {
-            "$ref": "#/definitions/columns"
+            "$ref": "shared.json#/definitions/columns"
         },
         "columnDefault": {
-            "$ref": "#/definitions/column"
+            "$ref": "shared.json#/definitions/column"
         },
         "columnCount": {
             "type": "number"
         }
     },
-    "additionalProperties": false,
-    "definitions": {
-        "columns": {
-            "type": "object",
-            "patternProperties": {
-                "^[0-9]+$": {
-                    "$ref": "#/definitions/column"
-                }
-            },
-            "additionalProperties": false
-        },
-        "column": {
-            "type": "object",
-            "properties": {
-                "alignment": {
-                    "type": "string",
-                    "enum": [
-                        "left",
-                        "right",
-                        "center"
-                    ]
-                },
-                "width": {
-                    "type": "number"
-                },
-                "wrapWord": {
-                    "type": "boolean"
-                },
-                "truncate": {
-                    "type": "number"
-                },
-                "paddingLeft": {
-                    "type": "number"
-                },
-                "paddingRight": {
-                    "type": "number"
-                }
-            },
-            "additionalProperties": false
-        },
-        "borders": {
-            "type": "object",
-            "properties": {
-                "topBody": {
-                    "$ref": "#/definitions/border"
-                },
-                "topJoin": {
-                    "$ref": "#/definitions/border"
-                },
-                "topLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "topRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomBody": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomJoin": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "bottomRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "bodyLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "bodyRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "bodyJoin": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinBody": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinLeft": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinRight": {
-                    "$ref": "#/definitions/border"
-                },
-                "joinJoin": {
-                    "$ref": "#/definitions/border"
-                }
-            },
-            "additionalProperties": false
-        },
-        "border": {
-            "type": "string"
-        }
-    }
+    "additionalProperties": false
 }

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,12 +1,5 @@
 // eslint-disable-next-line import/default
-import validateConfig from '../dist/validateConfig';
-// eslint-disable-next-line import/default
-import validateStreamConfig from '../dist/validateStreamConfig';
-
-const validate = {
-  'config.json': validateConfig,
-  'streamConfig.json': validateStreamConfig,
-};
+import validators from '../dist/validators';
 
 /**
  * @param {string} schemaId
@@ -14,8 +7,9 @@ const validate = {
  * @returns {undefined}
  */
 export default (schemaId, config = {}) => {
-  if (!validate[schemaId](config)) {
-    const errors = validate[schemaId].errors.map((error) => {
+  const validate = validators[schemaId];
+  if (!validate(config)) {
+    const errors = validate.errors.map((error) => {
       return {
         dataPath: error.dataPath,
         message: error.message,

--- a/test/config.js
+++ b/test/config.js
@@ -3,9 +3,12 @@ import ajvKeywords from 'ajv-keywords';
 import {
   expect,
 } from 'chai';
-import validateConfig from '../dist/validateConfig';
+import validators from '../dist/validators';
 import configSchema from '../src/schemas/config.json';
+import sharedSchema from '../src/schemas/shared.json';
 import configSamples from './configSamples';
+
+const validateConfig = validators['config.json'];
 
 describe('config.json schema', () => {
   let validate;
@@ -14,6 +17,7 @@ describe('config.json schema', () => {
     const ajv = new Ajv({allErrors: true});
 
     ajvKeywords(ajv, 'typeof');
+    ajv.addSchema(sharedSchema);
     validate = ajv.compile(configSchema);
   });
 

--- a/test/streamConfig.js
+++ b/test/streamConfig.js
@@ -4,9 +4,12 @@ import ajvSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
 import {
   expect,
 } from 'chai';
-import validateConfig from '../dist/validateStreamConfig';
+import validators from '../dist/validators';
+import sharedSchema from '../src/schemas/shared.json';
 import configSchema from '../src/schemas/streamConfig.json';
 import configSamples from './streamConfigSamples';
+
+const validateConfig = validators['streamConfig.json'];
 
 describe('streamConfig.json schema', () => {
   let validate;
@@ -19,7 +22,7 @@ describe('streamConfig.json schema', () => {
     ajv.addMetaSchema(ajvSchemaDraft06);
 
     ajvKeywords(ajv, 'typeof');
-
+    ajv.addSchema(sharedSchema);
     validate = ajv.compile(configSchema);
   });
 


### PR DESCRIPTION
@gajus please have a look.

The changes are:
- switch to ajv v7 - now it compiles both schemas to one file with 2 exports - it reduced the size of compiled code (there is a big shared part) and simplified the code on the call site a bit.
- refactored schemas to extract shared part. It didn't affect compiled code size - I thought it would - as ajv was already re-using code from duplicated schemas, but I kept it anyway, the schemas are smaller this way - easier to change if needed.
- js-beautify is no longer included in ajv-pack (there is no ajv-pack too, standalone code generation is included in ajv now), so it is imported directly to format code. It is not necessary, strictly speaking, maybe the compiled code could be just one big string - let me know.

Should it be a major version upgrade? There is no API changes here, but eslint etc. would have 2 different ajv versions in the tree if it's not - not sure if it may cause any conflicts? It is probably worth releasing as minor version and roll-back if there are any unresolvable conflicts.

In any case please hold it until Ajv v7 is released as main version.