### PR TITLE
Add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 coverage
 dist
 *.log


### PR DESCRIPTION
I accidentally added package-lock to a commit.
Adding it to the gitignore to help future devs.
