### PR TITLE
Upgrade AJV to version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "ajv": "^7.0.2",
+    "ajv": "^8.0.1",
     "is-boolean-object": "^1.1.0",
     "is-number-object": "^1.0.4",
     "is-string": "^1.0.5",
@@ -25,8 +25,8 @@
     "@babel/plugin-transform-flow-strip-types": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/register": "^7.12.10",
-    "ajv-cli": "^4.0.1",
-    "ajv-keywords": "^4.0.0",
+    "ajv-cli": "^5.0.0",
+    "ajv-keywords": "^5.0.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-transform-export-default-name": "^2.1.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
The breaking changes are minimal: https://github.com/ajv-validator/ajv/releases/tag/v8.0.0

All tests pass without code modification.