### PR TITLE
Don't ship source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "url": "https://github.com/gajus/table"
   },
   "scripts": {
-    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps && npm run create-validators && flow-copy-source src dist",
+    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files && npm run create-validators && flow-copy-source src dist",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md",
     "create-validators": "ajv compile --all-errors --inline-refs=false -s src/schemas/config -s src/schemas/streamConfig -r src/schemas/shared -c ajv-keywords/dist/keywords/typeof -o | js-beautify > dist/validators.js",
     "lint": "npm run build && eslint ./src ./test && flow",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",
-    "@babel/node": "^7.12.10",
     "@babel/plugin-transform-flow-strip-types": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/register": "^7.12.10",


### PR DESCRIPTION
In the spirit of #137 I've extracted one change from #129 which is to no longer generate source maps.

Since the shipped code is not minified and in-fact there's only two transformations running (adding function names and converting ESM->CJS) there's little value in shipping them.

This reduces the size of the `dist` folder by 42%. (ca. 150kB)