### PR TITLE
Don't ship flow files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,8 +7,7 @@
     }
   },
   "plugins": [
-    "transform-export-default-name",
-    "@babel/transform-flow-strip-types"
+    "transform-export-default-name"
   ],
   "presets": [
     [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",
-    "@babel/plugin-transform-flow-strip-types": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/register": "^7.12.10",
     "ajv-cli": "^5.0.0",
@@ -32,7 +31,6 @@
     "eslint": "^7.16.0",
     "eslint-config-canonical": "^25.0.0",
     "flow-bin": "^0.141.0",
-    "flow-copy-source": "^2.0.9",
     "gitdown": "^3.1.3",
     "husky": "^4.3.6",
     "js-beautify": "^1.13.0",
@@ -81,7 +79,7 @@
     "url": "https://github.com/gajus/table"
   },
   "scripts": {
-    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files && npm run create-validators && flow-copy-source src dist",
+    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files && npm run create-validators",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md",
     "create-validators": "ajv compile --all-errors --inline-refs=false -s src/schemas/config -s src/schemas/streamConfig -r src/schemas/shared -c ajv-keywords/dist/keywords/typeof -o | js-beautify > dist/validators.js",
     "lint": "npm run build && eslint ./src ./test && flow",


### PR DESCRIPTION
Looking a bit more at the structure of the npm package and where its size comes from (see #137), the flow files stood out.

There are currently no flow types and Flow does [not interpret JSDoc comments](https://github.com/facebook/flow/issues/5670). This reduces the size of the dist folder by ~60%.