### PR TITLE
Optimize text truncation

### DIFF
--- a/.README/usage/text_truncation.md
+++ b/.README/usage/text_truncation.md
@@ -33,6 +33,6 @@ console.log(output);
 ║ t amet, consectetur  ║
 ║ adipiscing elit. Pha ║
 ║ sellus pulvinar nibh ║
-║ sed mauris conva...  ║
+║ sed mauris convall…  ║
 ╚══════════════════════╝
 ```

--- a/src/truncateTableData.js
+++ b/src/truncateTableData.js
@@ -11,6 +11,7 @@ export default (rows, config) => {
     return cells.map((content, index) => {
       return truncate(content, {
         length: config.columns[index].truncate,
+        omission: '…',
       });
     });
   });

--- a/test/README/usage/text_truncating.js
+++ b/test/README/usage/text_truncating.js
@@ -26,7 +26,7 @@ describe('README.md usage/', () => {
 ║ t amet, consectetur  ║
 ║ adipiscing elit. Pha ║
 ║ sellus pulvinar nibh ║
-║ sed mauris conva...  ║
+║ sed mauris convall…  ║
 ╚══════════════════════╝
         `);
   });

--- a/test/truncateTableData.js
+++ b/test/truncateTableData.js
@@ -22,7 +22,7 @@ describe('truncateTableData', () => {
 
         expect(truncateTableData(rows, makeConfig(rows, {columnDefault: {
           truncate: 20,
-        }}))).to.deep.equal([['a'.repeat(17) + '...']]);
+        }}))).to.deep.equal([['a'.repeat(19) + '…']]);
       });
     });
 
@@ -39,7 +39,7 @@ describe('truncateTableData', () => {
               truncate: 30,
             },
           },
-        }))).to.deep.equal([['a'.repeat(27) + '...']]);
+        }))).to.deep.equal([['a'.repeat(29) + '…']]);
       });
     });
   });
@@ -57,7 +57,48 @@ describe('truncateTableData', () => {
             truncate: 30,
           },
         },
-      }))).to.deep.equal([['a'.repeat(27) + '...', 'b'.repeat(17) + '...'], ['c'.repeat(27) + '...', 'd'.repeat(17) + '...']]);
+      }))).to.deep.equal([
+        ['a'.repeat(29) + '…', 'b'.repeat(19) + '…'],
+        ['c'.repeat(29) + '…', 'd'.repeat(19) + '…']]);
+    });
+  });
+
+  context('edge cases', () => {
+    context('truncate = 0', () => {
+      it('returns ellipsis only', () => {
+        const rows = [['a'.repeat(100)]];
+        expect(truncateTableData(rows, makeConfig(rows, {
+          columns: {0: {truncate: 0}},
+        }))).to.deep.equal([['…']]);
+      });
+    });
+
+    context('truncate = 1', () => {
+      it('returns ellipsis only', () => {
+        const rows = [['a'.repeat(100)]];
+        expect(truncateTableData(rows, makeConfig(rows, {
+          columns: {0: {truncate: 1}},
+
+        }))).to.deep.equal([['…']]);
+      });
+    });
+
+    context('truncate = 2', () => {
+      it('returns 2-length string with ellipsis', () => {
+        const rows = [['a'.repeat(100)]];
+        expect(truncateTableData(rows, makeConfig(rows, {
+          columns: {0: {truncate: 2}},
+        }))).to.deep.equal([['a…']]);
+      });
+    });
+
+    context('empty string', () => {
+      it('returns empty string', () => {
+        const rows = [['']];
+        expect(truncateTableData(rows, makeConfig(rows, {
+          columns: {0: {truncate: 100}},
+        }))).to.deep.equal([['']]);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR optimizes text truncation by use 1-length ellipsis '…' instead of 3-length one '...'. (#105)