### PR TITLE
Restore function names

### DIFF
--- a/src/alignString.ts
+++ b/src/alignString.ts
@@ -29,7 +29,7 @@ const alignCenter = (subject: string, width: number): string => {
  * Pads a string to the left and/or right to position the subject
  * text in a desired alignment within a container.
  */
-export default (subject: string, containerWidth: number, alignment: ColumnUserConfig['alignment']): string => {
+export const alignString = (subject: string, containerWidth: number, alignment: ColumnUserConfig['alignment']): string => {
   const subjectWidth = stringWidth(subject);
 
   if (subjectWidth > containerWidth) {

--- a/src/alignTableData.ts
+++ b/src/alignTableData.ts
@@ -1,11 +1,13 @@
 import stringWidth from 'string-width';
-import alignString from './alignString';
+import {
+  alignString,
+} from './alignString';
 import type {
   BaseConfig,
   Row,
 } from './types/internal';
 
-export default (rows: Row[], config: BaseConfig): Row[] => {
+export const alignTableData = (rows: Row[], config: BaseConfig): Row[] => {
   return rows.map((row) => {
     return row.map((cell, cellIndex) => {
       const column = config.columns[cellIndex];

--- a/src/calculateCellHeight.ts
+++ b/src/calculateCellHeight.ts
@@ -1,8 +1,10 @@
-import wrapCell from './wrapCell';
+import {
+  wrapCell,
+} from './wrapCell';
 
 /**
  * Calculates height of cell content in regard to its width and word wrapping.
  */
-export default (value: string, columnWidth: number, useWrapWord = false): number => {
+export const calculateCellHeight = (value: string, columnWidth: number, useWrapWord = false): number => {
   return wrapCell(value, columnWidth, useWrapWord).length;
 };

--- a/src/calculateCellWidths.ts
+++ b/src/calculateCellWidths.ts
@@ -6,7 +6,7 @@ import type {
 /**
  * Calculates width of each cell contents in a row.
  */
-export default (cells: Cell[]): number[] => {
+export const calculateCellWidths = (cells: Cell[]): number[] => {
   return cells.map((cell) => {
     return Math.max(
       ...cell.split('\n').map(stringWidth),

--- a/src/calculateColumnWidths.ts
+++ b/src/calculateColumnWidths.ts
@@ -1,4 +1,6 @@
-import calculateCellWidths from './calculateCellWidths';
+import {
+  calculateCellWidths,
+} from './calculateCellWidths';
 import type {
   Row,
 } from './types/internal';

--- a/src/calculateRowHeights.ts
+++ b/src/calculateRowHeights.ts
@@ -1,4 +1,6 @@
-import calculateCellHeight from './calculateCellHeight';
+import {
+  calculateCellHeight,
+} from './calculateCellHeight';
 import type {
   BaseConfig,
   Row,
@@ -7,7 +9,7 @@ import type {
 /**
  * Produces an array of values that describe the largest value length (height) in every row.
  */
-export default (rows: Row[], config: BaseConfig): number[] => {
+export const calculateRowHeights = (rows: Row[], config: BaseConfig): number[] => {
   return rows.map((row) => {
     let rowHeight = 1;
 

--- a/src/createStream.ts
+++ b/src/createStream.ts
@@ -1,16 +1,32 @@
-import alignTableData from './alignTableData';
-import calculateRowHeights from './calculateRowHeights';
+import {
+  alignTableData,
+} from './alignTableData';
+import {
+  calculateRowHeights,
+} from './calculateRowHeights';
 import {
   drawBorderBottom,
   drawBorderJoin,
   drawBorderTop,
 } from './drawBorder';
-import drawRow from './drawRow';
-import makeStreamConfig from './makeStreamConfig';
-import mapDataUsingRowHeights from './mapDataUsingRowHeights';
-import padTableData from './padTableData';
-import stringifyTableData from './stringifyTableData';
-import truncateTableData from './truncateTableData';
+import {
+  drawRow,
+} from './drawRow';
+import {
+  makeStreamConfig,
+} from './makeStreamConfig';
+import {
+  mapDataUsingRowHeights,
+} from './mapDataUsingRowHeights';
+import {
+  padTableData,
+} from './padTableData';
+import {
+  stringifyTableData,
+} from './stringifyTableData';
+import {
+  truncateTableData,
+} from './truncateTableData';
 import type {
   StreamUserConfig,
   WritableStream,
@@ -76,7 +92,7 @@ const append = (row: Row, columnWidths: number[], config: StreamConfig) => {
   process.stdout.write(output);
 };
 
-export default (userConfig: StreamUserConfig): WritableStream => {
+export const createStream = (userConfig: StreamUserConfig): WritableStream => {
   const config = makeStreamConfig(userConfig);
 
   const columnWidths = Object.values(config.columns).map((column) => {

--- a/src/drawBorder.ts
+++ b/src/drawBorder.ts
@@ -1,4 +1,6 @@
-import drawContent from './drawContent';
+import {
+  drawContent,
+} from './drawContent';
 import type {
   DrawVerticalLine,
 } from './types/api';

--- a/src/drawContent.ts
+++ b/src/drawContent.ts
@@ -9,7 +9,7 @@ type SeparatorConfig = {
  * Shared function to draw horizontal borders, rows or the entire table
  */
 
-export default function drawContent (contents: string[], separatorConfig: SeparatorConfig): string {
+export const drawContent = (contents: string[], separatorConfig: SeparatorConfig): string => {
   const {startSeparator, middleSeparator, endSeparator, drawSeparator} = separatorConfig;
   const contentSize = contents.length;
   const result: string[] = [];
@@ -32,4 +32,4 @@ export default function drawContent (contents: string[], separatorConfig: Separa
   }
 
   return result.join('');
-}
+};

--- a/src/drawRow.ts
+++ b/src/drawRow.ts
@@ -1,4 +1,6 @@
-import drawContent from './drawContent';
+import {
+  drawContent,
+} from './drawContent';
 import type {
   DrawVerticalLine,
 } from './types/api';
@@ -6,7 +8,7 @@ import type {
   BodyBorderConfig, Row,
 } from './types/internal';
 
-export default (row: Row, config: {
+export const drawRow = (row: Row, config: {
   border: BodyBorderConfig,
   drawVerticalLine: DrawVerticalLine,
 }): string => {

--- a/src/drawTable.ts
+++ b/src/drawTable.ts
@@ -1,8 +1,12 @@
 import {
   drawBorderTop, drawBorderJoin, drawBorderBottom,
 } from './drawBorder';
-import drawContent from './drawContent';
-import drawRow from './drawRow';
+import {
+  drawContent,
+} from './drawContent';
+import {
+  drawRow,
+} from './drawRow';
 import type {
   TableConfig, Row,
 } from './types/internal';
@@ -10,7 +14,7 @@ import {
   groupBySizes,
 } from './utils';
 
-export default (rows: Row[], columnWidths: number[], rowHeights: number[], config: TableConfig): string => {
+export const drawTable = (rows: Row[], columnWidths: number[], rowHeights: number[], config: TableConfig): string => {
   const {
     drawHorizontalLine,
     singleLine,

--- a/src/getBorderCharacters.ts
+++ b/src/getBorderCharacters.ts
@@ -4,7 +4,7 @@ import type {
   BorderConfig,
 } from './types/api';
 
-export default (name: string): BorderConfig => {
+export const getBorderCharacters = (name: string): BorderConfig => {
   if (name === 'honeywell') {
     return {
       topBody: '═',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
-import createStream from './createStream';
-import getBorderCharacters from './getBorderCharacters';
-import table from './table';
+import {
+  createStream,
+} from './createStream';
+import {
+  getBorderCharacters,
+} from './getBorderCharacters';
+import {
+  table,
+} from './table';
 
 export {
   table,
@@ -9,4 +15,3 @@ export {
 };
 
 export * from './types/api';
-

--- a/src/makeConfig.ts
+++ b/src/makeConfig.ts
@@ -10,7 +10,9 @@ import type {
 import {
   makeBorder,
 } from './utils';
-import validateConfig from './validateConfig';
+import {
+  validateConfig,
+} from './validateConfig';
 
 /**
  * Creates a configuration for every column using default
@@ -40,7 +42,7 @@ const makeColumns = (rows: Row[],
  * using default values for the missing configuration properties.
  */
 
-export default (rows: Row[], userConfig: TableUserConfig = {}): TableConfig => {
+export const makeConfig = (rows: Row[], userConfig: TableUserConfig = {}): TableConfig => {
   validateConfig('config.json', userConfig);
 
   const config = cloneDeep(userConfig);

--- a/src/makeStreamConfig.ts
+++ b/src/makeStreamConfig.ts
@@ -11,7 +11,9 @@ import type {
 import {
   makeBorder,
 } from './utils';
-import validateConfig from './validateConfig';
+import {
+  validateConfig,
+} from './validateConfig';
 
 /**
  * Creates a configuration for every column using default
@@ -37,7 +39,7 @@ const makeColumns = (columnCount: number,
  * Makes a new configuration object out of the userConfig object
  * using default values for the missing configuration properties.
  */
-export default (userConfig: StreamUserConfig): StreamConfig => {
+export const makeStreamConfig = (userConfig: StreamUserConfig): StreamConfig => {
   validateConfig('streamConfig.json', userConfig);
 
   const config = cloneDeep(userConfig);

--- a/src/mapDataUsingRowHeights.ts
+++ b/src/mapDataUsingRowHeights.ts
@@ -3,9 +3,11 @@ import type {
   BaseConfig,
   Row,
 } from './types/internal';
-import wrapCell from './wrapCell';
+import {
+  wrapCell,
+} from './wrapCell';
 
-export default (unmappedRows: Row[], rowHeights: number[], config: BaseConfig): Row[] => {
+export const mapDataUsingRowHeights = (unmappedRows: Row[], rowHeights: number[], config: BaseConfig): Row[] => {
   const tableWidth = unmappedRows[0].length;
 
   const mappedRows = unmappedRows.map((unmappedRow, unmappedRowIndex) => {

--- a/src/padTableData.ts
+++ b/src/padTableData.ts
@@ -3,7 +3,7 @@ import type {
   Row,
 } from './types/internal';
 
-export default (rows: Row[], config: BaseConfig): Row[] => {
+export const padTableData = (rows: Row[], config: BaseConfig): Row[] => {
   return rows.map((cells) => {
     return cells.map((cell, cellIndex) => {
       const column = config.columns[cellIndex];

--- a/src/stringifyTableData.ts
+++ b/src/stringifyTableData.ts
@@ -5,7 +5,7 @@ import {
   normalizeString,
 } from './utils';
 
-export default (rows: unknown[][]): Row[] => {
+export const stringifyTableData = (rows: unknown[][]): Row[] => {
   return rows.map((cells) => {
     return cells.map((cell) => {
       return normalizeString(String(cell));

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,18 +1,38 @@
-import alignTableData from './alignTableData';
-import calculateCellWidths from './calculateCellWidths';
-import calculateRowHeights from './calculateRowHeights';
-import drawTable from './drawTable';
-import makeConfig from './makeConfig';
-import mapDataUsingRowHeights from './mapDataUsingRowHeights';
-import padTableData from './padTableData';
-import stringifyTableData from './stringifyTableData';
-import truncateTableData from './truncateTableData';
+import {
+  alignTableData,
+} from './alignTableData';
+import {
+  calculateCellWidths,
+} from './calculateCellWidths';
+import {
+  calculateRowHeights,
+} from './calculateRowHeights';
+import {
+  drawTable,
+} from './drawTable';
+import {
+  makeConfig,
+} from './makeConfig';
+import {
+  mapDataUsingRowHeights,
+} from './mapDataUsingRowHeights';
+import {
+  padTableData,
+} from './padTableData';
+import {
+  stringifyTableData,
+} from './stringifyTableData';
+import {
+  truncateTableData,
+} from './truncateTableData';
 import type {
   TableUserConfig,
 } from './types/api';
-import validateTableData from './validateTableData';
+import {
+  validateTableData,
+} from './validateTableData';
 
-export default (data: unknown[][], userConfig: TableUserConfig = {}): string => {
+export const table = (data: unknown[][], userConfig: TableUserConfig = {}): string => {
   validateTableData(data);
 
   let rows = stringifyTableData(data);

--- a/src/truncateTableData.ts
+++ b/src/truncateTableData.ts
@@ -6,7 +6,7 @@ import type {
 /**
  * @todo Make it work with ASCII content.
  */
-export default (rows: Row[], config: BaseConfig): Row[] => {
+export const truncateTableData = (rows: Row[], config: BaseConfig): Row[] => {
   return rows.map((cells) => {
     return cells.map((cell, cellIndex) => {
       return truncate(cell, {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import slice from 'slice-ansi';
 import stripAnsi from 'strip-ansi';
-import getBorderCharacters from './getBorderCharacters';
+import {
+  getBorderCharacters,
+} from './getBorderCharacters';
 import type {
   BorderConfig, BorderUserConfig,
 } from './types/api';

--- a/src/validateConfig.ts
+++ b/src/validateConfig.ts
@@ -7,7 +7,7 @@ import type {
   TableUserConfig,
 } from './types/api';
 
-export default (schemaId: 'config.json'|'streamConfig.json', config: TableUserConfig): void => {
+export const validateConfig = (schemaId: 'config.json'|'streamConfig.json', config: TableUserConfig): void => {
   const validate = validators[schemaId] as ValidateFunction;
   if (!validate(config) && validate.errors) {
     const errors = validate.errors.map((error: ErrorObject) => {

--- a/src/validateTableData.ts
+++ b/src/validateTableData.ts
@@ -2,7 +2,7 @@ import {
   normalizeString,
 } from './utils';
 
-export default (rows: unknown[][]): void => {
+export const validateTableData = (rows: unknown[][]): void => {
   if (!Array.isArray(rows)) {
     throw new TypeError('Table data must be an array.');
   }

--- a/src/wrapCell.ts
+++ b/src/wrapCell.ts
@@ -1,8 +1,12 @@
 import {
   splitAnsi,
 } from './utils';
-import wrapString from './wrapString';
-import wrapWord from './wrapWord';
+import {
+  wrapString,
+} from './wrapString';
+import {
+  wrapWord,
+} from './wrapWord';
 
 /**
  * Wrap a single cell value into a list of lines
@@ -11,7 +15,7 @@ import wrapWord from './wrapWord';
  * depending on user configuration.
  *
  */
-export default (cellValue: string, cellWidth: number, useWrapWord: boolean): string[] => {
+export const wrapCell = (cellValue: string, cellWidth: number, useWrapWord: boolean): string[] => {
   // First split on literal newlines
   const cellLines = splitAnsi(cellValue);
 

--- a/src/wrapString.ts
+++ b/src/wrapString.ts
@@ -9,7 +9,7 @@ import stringWidth from 'string-width';
  * in that whitespace characters that occur on a chunk size limit are trimmed.
  *
  */
-export default (subject: string, size: number): string[] => {
+export const wrapString = (subject: string, size: number): string[] => {
   let subjectSlice = subject;
 
   const chunks: string[] = [];

--- a/src/wrapWord.ts
+++ b/src/wrapWord.ts
@@ -34,7 +34,7 @@ const calculateStringLengths = (input: string, size: number): Array<[Length:numb
   return chunks;
 };
 
-export default (input: string, size: number): string[] => {
+export const wrapWord = (input: string, size: number): string[] => {
   const result: string[] = [];
 
   let startIndex = 0;

--- a/test/alignString.ts
+++ b/test/alignString.ts
@@ -4,7 +4,9 @@ import {
   expect,
 } from 'chai';
 import chalk from 'chalk';
-import alignString from '../src/alignString';
+import {
+  alignString,
+} from '../src/alignString';
 
 describe('alignString', () => {
   context('subject parameter value width is greater than the container width', () => {

--- a/test/alignTableData.ts
+++ b/test/alignTableData.ts
@@ -4,8 +4,12 @@ import {
   expect,
 } from 'chai';
 import chalk from 'chalk';
-import alignTableData from '../src/alignTableData';
-import makeConfig from '../src/makeConfig';
+import {
+  alignTableData,
+} from '../src/alignTableData';
+import {
+  makeConfig,
+} from '../src/makeConfig';
 
 describe('alignTableData', () => {
   context('when the string width is equal to column width config', () => {

--- a/test/calculateCellHeight.ts
+++ b/test/calculateCellHeight.ts
@@ -3,7 +3,9 @@
 import {
   expect,
 } from 'chai';
-import calculateCellHeight from '../src/calculateCellHeight';
+import {
+  calculateCellHeight,
+} from '../src/calculateCellHeight';
 
 describe('calculateCellHeight', () => {
   describe('value', () => {

--- a/test/calculateCellWidths.ts
+++ b/test/calculateCellWidths.ts
@@ -1,7 +1,9 @@
 import {
   expect,
 } from 'chai';
-import calculateCellWidths from '../src/calculateCellWidths';
+import {
+  calculateCellWidths,
+} from '../src/calculateCellWidths';
 
 describe('calculateCellWidths', () => {
   context('all cells have different width', () => {

--- a/test/calculateRowHeights.ts
+++ b/test/calculateRowHeights.ts
@@ -3,8 +3,12 @@
 import {
   expect,
 } from 'chai';
-import calculateRowHeights from '../src/calculateRowHeights';
-import makeConfig from '../src/makeConfig';
+import {
+  calculateRowHeights,
+} from '../src/calculateRowHeights';
+import {
+  makeConfig,
+} from '../src/makeConfig';
 
 describe('calculateRowHeights', () => {
   context('single column', () => {

--- a/test/createStream.ts
+++ b/test/createStream.ts
@@ -5,8 +5,12 @@ import {
 } from 'chai';
 // eslint-disable-next-line import/no-namespace
 import * as Sinon from 'sinon';
-import createStream from '../src/createStream';
-import getBorderCharacters from '../src/getBorderCharacters';
+import {
+  createStream,
+} from '../src/createStream';
+import {
+  getBorderCharacters,
+} from '../src/getBorderCharacters';
 
 describe('createStream', () => {
   context('"config.columnDefault.width" property is not provided', () => {

--- a/test/drawRow.ts
+++ b/test/drawRow.ts
@@ -1,7 +1,9 @@
 import {
   expect,
 } from 'chai';
-import drawRow from '../src/drawRow';
+import {
+  drawRow,
+} from '../src/drawRow';
 
 const drawVerticalLine = () => {
   return true;

--- a/test/drawTable.ts
+++ b/test/drawTable.ts
@@ -6,7 +6,9 @@ import {
 import type {
   TableUserConfig,
 } from '../src';
-import table from '../src/table';
+import {
+  table,
+} from '../src/table';
 
 const data = [
   ['Lorem ipsum', 'dolor sit'],

--- a/test/getBorderCharacters.ts
+++ b/test/getBorderCharacters.ts
@@ -3,7 +3,9 @@
 import {
   expect,
 } from 'chai';
-import getBorderCharacters from '../src/getBorderCharacters';
+import {
+  getBorderCharacters,
+} from '../src/getBorderCharacters';
 
 describe('getBorderCharacters', () => {
   context('given name \'honeywell\'', () => {

--- a/test/makeConfig.ts
+++ b/test/makeConfig.ts
@@ -3,7 +3,9 @@
 import {
   expect,
 } from 'chai';
-import makeConfig from '../src/makeConfig';
+import {
+  makeConfig,
+} from '../src/makeConfig';
 
 describe('makeConfig', () => {
   const rows = [['aaaaa']];

--- a/test/makeStreamConfig.ts
+++ b/test/makeStreamConfig.ts
@@ -6,7 +6,9 @@ import {
 import type {
   StreamUserConfig,
 } from '../src';
-import makeStreamConfig from '../src/makeStreamConfig';
+import {
+  makeStreamConfig,
+} from '../src/makeStreamConfig';
 
 const baseStreamConfig: StreamUserConfig = {
   columnCount: 1,

--- a/test/mapDataUsingRowHeights.ts
+++ b/test/mapDataUsingRowHeights.ts
@@ -2,8 +2,12 @@ import {
   expect,
 } from 'chai';
 import chalk from 'chalk';
-import makeConfig from '../src/makeConfig';
-import mapDataUsingRowHeights from '../src/mapDataUsingRowHeights';
+import {
+  makeConfig,
+} from '../src/makeConfig';
+import {
+  mapDataUsingRowHeights,
+} from '../src/mapDataUsingRowHeights';
 
 describe('mapDataUsingRowHeights', () => {
   context('no data spans multiple rows', () => {

--- a/test/padTableData.ts
+++ b/test/padTableData.ts
@@ -3,8 +3,12 @@
 import {
   expect,
 } from 'chai';
-import makeConfig from '../src/makeConfig';
-import padTableData from '../src/padTableData';
+import {
+  makeConfig,
+} from '../src/makeConfig';
+import {
+  padTableData,
+} from '../src/padTableData';
 
 describe('padTableData', () => {
   context('when no given userConfig', () => {

--- a/test/stringifyTableData.ts
+++ b/test/stringifyTableData.ts
@@ -1,7 +1,9 @@
 import {
   expect,
 } from 'chai';
-import stringifyTableData from '../src/stringifyTableData';
+import {
+  stringifyTableData,
+} from '../src/stringifyTableData';
 
 describe('stringifyTableData', () => {
   it('converts all cell values to strings', () => {

--- a/test/truncateTableData.ts
+++ b/test/truncateTableData.ts
@@ -3,8 +3,12 @@
 import {
   expect,
 } from 'chai';
-import makeConfig from '../src/makeConfig';
-import truncateTableData from '../src/truncateTableData';
+import {
+  makeConfig,
+} from '../src/makeConfig';
+import {
+  truncateTableData,
+} from '../src/truncateTableData';
 
 describe('truncateTableData', () => {
   context('when no given userConfig', () => {

--- a/test/validateConfig.ts
+++ b/test/validateConfig.ts
@@ -3,7 +3,9 @@
 import {
   expect,
 } from 'chai';
-import validateConfig from '../src/validateConfig';
+import {
+  validateConfig,
+} from '../src/validateConfig';
 
 describe('validateConfig', () => {
   context('given invalid config', () => {

--- a/test/validateTableData.ts
+++ b/test/validateTableData.ts
@@ -6,7 +6,9 @@ import {
 import {
   table,
 } from '../src';
-import validateTableData from '../src/validateTableData';
+import {
+  validateTableData,
+} from '../src/validateTableData';
 
 describe('validateTableData', () => {
   context('table does not have a row', () => {

--- a/test/wrapCell.ts
+++ b/test/wrapCell.ts
@@ -3,9 +3,15 @@
 import {
   expect,
 } from 'chai';
-import wrapCell from '../src/wrapCell';
-import wrapString from '../src/wrapString';
-import wrapWord from '../src/wrapWord';
+import {
+  wrapCell,
+} from '../src/wrapCell';
+import {
+  wrapString,
+} from '../src/wrapString';
+import {
+  wrapWord,
+} from '../src/wrapWord';
 import {
   arrayToRed,
   stringToRed,

--- a/test/wrapString.ts
+++ b/test/wrapString.ts
@@ -3,7 +3,9 @@
 import {
   expect,
 } from 'chai';
-import wrapString from '../src/wrapString';
+import {
+  wrapString,
+} from '../src/wrapString';
 
 describe('wrapString', () => {
   context('subject is a plain text string', () => {

--- a/test/wrapWord.ts
+++ b/test/wrapWord.ts
@@ -1,7 +1,9 @@
 import {
   expect,
 } from 'chai';
-import wrapWord from '../src/wrapWord';
+import {
+  wrapWord,
+} from '../src/wrapWord';
 import {
   arrayToRed, closeRed, openRed, stringToRed,
 } from './utils';


### PR DESCRIPTION
This is a small regression from #147 where the babel plugin that adds function names to the default exports was removed. Instead of reintroducing babel just for that plug-in, I'd propose to just add the function names manually. This is mainly nice for stack traces to be more useful.

cc @nam-hle 