### PR TITLE
Wrap word support ansi

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "lodash.truncate": "^4.4.2",
     "slice-ansi": "^4.0.0",
     "string-width": "^4.2.0",
-    "strip-ansi": "^6.0.0",
-    "wrap-ansi": "^7.0.0"
+    "strip-ansi": "^6.0.0"
   },
   "description": "Formats data into a string table.",
   "devDependencies": {
@@ -28,7 +27,6 @@
     "@types/node": "^14.14.37",
     "@types/sinon": "^10.0.0",
     "@types/slice-ansi": "^4.0.0",
-    "@types/wrap-ansi": "^3.0.0",
     "ajv-cli": "^5.0.0",
     "ajv-keywords": "^5.0.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lodash.flatten": "^4.4.0",
     "lodash.truncate": "^4.4.2",
     "slice-ansi": "^4.0.0",
-    "string-width": "^4.2.0"
+    "string-width": "^4.2.0",
+    "strip-ansi": "^6.0.0",
+    "wrap-ansi": "^7.0.0"
   },
   "description": "Formats data into a string table.",
   "devDependencies": {
@@ -26,6 +28,7 @@
     "@types/node": "^14.14.37",
     "@types/sinon": "^10.0.0",
     "@types/slice-ansi": "^4.0.0",
+    "@types/wrap-ansi": "^3.0.0",
     "ajv-cli": "^5.0.0",
     "ajv-keywords": "^5.0.0",
     "chai": "^4.2.0",

--- a/src/wrapCell.ts
+++ b/src/wrapCell.ts
@@ -1,5 +1,25 @@
+import slice from 'slice-ansi';
+import stripAnsi from 'strip-ansi';
 import wrapString from './wrapString';
 import wrapWord from './wrapWord';
+
+const splitAnsi = (input: string) => {
+  const lengths = stripAnsi(input).split('\n').map(({length}) => {
+    return length;
+  });
+
+  const result: string[] = [];
+  let startIndex = 0;
+
+  lengths.forEach((length) => {
+    result.push(length === 0 ? '' : slice(input, startIndex, startIndex + length));
+
+    // Plus 1 for the newline character itself
+    startIndex += length + 1;
+  });
+
+  return result;
+};
 
 /**
  * Wrap a single cell value into a list of lines
@@ -10,7 +30,7 @@ import wrapWord from './wrapWord';
  */
 export default (cellValue: string, columnWidth: number, useWrapWord: boolean): string[] => {
   // First split on literal newlines
-  const cellLines = cellValue.split('\n');
+  const cellLines = splitAnsi(cellValue);
 
   // Then iterate over the list and word-wrap every remaining line if necessary.
   for (let lineNr = 0; lineNr < cellLines.length;) {

--- a/src/wrapWord.ts
+++ b/src/wrapWord.ts
@@ -1,5 +1,33 @@
 import slice from 'slice-ansi';
 import stringWidth from 'string-width';
+import stripAnsi from 'strip-ansi';
+import wrapAnsi from 'wrap-ansi';
+
+const indexAnsi = (input: string, index: number): string => {
+  return stripAnsi(slice(input, index, index + 1));
+};
+
+const trimAnsi = (input: string): string => {
+  let startIndex = 0;
+  for (; startIndex < stringWidth(input); startIndex++) {
+    if (indexAnsi(input, startIndex) !== ' ') {
+      break;
+    }
+  }
+
+  let endIndex = stringWidth(input) - 1;
+  for (;endIndex >= 0; endIndex--) {
+    if (indexAnsi(input, endIndex) !== ' ') {
+      break;
+    }
+  }
+
+  return slice(input, startIndex, endIndex + 1);
+};
+
+const sliceWrap = (input: string, size: number): string => {
+  return wrapAnsi(input, size, {hard: true}).split('\n')[0];
+};
 
 export default (input: string, size: number): string[] => {
   let subject = input;
@@ -10,18 +38,19 @@ export default (input: string, size: number): string[] => {
   const re = new RegExp('(^.{1,' + String(size) + '}(\\s+|$))|(^.{1,' + String(size - 1) + '}(\\\\|/|_|\\.|,|;|-))');
 
   do {
-    let chunk;
+    let chunk: string;
 
-    chunk = re.exec(subject);
+    const match = re.exec(stripAnsi(subject));
 
-    if (chunk) {
-      chunk = chunk[0];
+    if (match) {
+      const firstMatch = match[0];
 
-      subject = slice(subject, stringWidth(chunk));
+      chunk = slice(subject, 0, firstMatch.length);
+      subject = slice(subject, firstMatch.length);
 
-      chunk = chunk.trim();
+      chunk = trimAnsi(chunk);
     } else {
-      chunk = slice(subject, 0, size);
+      chunk = sliceWrap(subject, size);
       subject = slice(subject, size);
     }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,12 @@
+export const openRed = '\u001b[31m';
+export const closeRed = '\u001b[39m';
+
+export const stringToRed = (string: string) => {
+  return openRed + string + closeRed;
+};
+
+export const arrayToRed = (array: string[]) => {
+  return array.map((string) => {
+    return string === '' ? '' : stringToRed(string);
+  });
+};

--- a/test/wrapCell.ts
+++ b/test/wrapCell.ts
@@ -6,6 +6,10 @@ import {
 import wrapCell from '../src/wrapCell';
 import wrapString from '../src/wrapString';
 import wrapWord from '../src/wrapWord';
+import {
+  arrayToRed,
+  stringToRed,
+} from './utils';
 
 describe('wrapCell', () => {
   const strings = ['aa bb cc', 'a a bb cccc', 'aaabbcc', 'a\\bb', 'a_bb', 'a-bb', 'a.bb', 'a,bb', 'a;bb'];
@@ -15,6 +19,7 @@ describe('wrapCell', () => {
       it('returns the same output as wrapWord\'s', () => {
         for (const string of strings) {
           expect(wrapCell(string, 3, true)).to.deep.equal(wrapWord(string, 3));
+          expect(wrapCell(stringToRed(string), 3, true)).to.deep.equal(arrayToRed(wrapWord(string, 3)));
         }
       });
     });
@@ -28,12 +33,23 @@ describe('wrapCell', () => {
           expect(wrapCell('\na\n', 5, true)).to.deep.equal(['', 'a', '']);
           expect(wrapCell('a\na', 5, true)).to.deep.equal(['a', 'a']);
           expect(wrapCell('a \na', 5, true)).to.deep.equal(['a', 'a']);
-
           expect(wrapCell('\n\n', 5, true)).to.deep.equal(['', '', '']);
           expect(wrapCell('a\n\n', 5, true)).to.deep.equal(['a', '', '']);
           expect(wrapCell('\n\na', 5, true)).to.deep.equal(['', '', 'a']);
           expect(wrapCell('a\n\nb', 5, true)).to.deep.equal(['a', '', 'b']);
           expect(wrapCell('a\n\n\nb', 5, true)).to.deep.equal(['a', '', '', 'b']);
+
+          expect(wrapCell(stringToRed('\n'), 5, true)).to.deep.equal(arrayToRed(['', '']));
+          expect(wrapCell(stringToRed('a\n'), 5, true)).to.deep.equal(arrayToRed(['a', '']));
+          expect(wrapCell(stringToRed('\na'), 5, true)).to.deep.equal(arrayToRed(['', 'a']));
+          expect(wrapCell(stringToRed('\na\n'), 5, true)).to.deep.equal(arrayToRed(['', 'a', '']));
+          expect(wrapCell(stringToRed('a\na'), 5, true)).to.deep.equal(arrayToRed(['a', 'a']));
+          expect(wrapCell(stringToRed('a \na'), 5, true)).to.deep.equal(arrayToRed(['a', 'a']));
+          expect(wrapCell(stringToRed('\n\n'), 5, true)).to.deep.equal(arrayToRed(['', '', '']));
+          expect(wrapCell(stringToRed('a\n\n'), 5, true)).to.deep.equal(arrayToRed(['a', '', '']));
+          expect(wrapCell(stringToRed('\n\na'), 5, true)).to.deep.equal(arrayToRed(['', '', 'a']));
+          expect(wrapCell(stringToRed('a\n\nb'), 5, true)).to.deep.equal(arrayToRed(['a', '', 'b']));
+          expect(wrapCell(stringToRed('a\n\n\nb'), 5, true)).to.deep.equal(arrayToRed(['a', '', '', 'b']));
         });
       });
 
@@ -41,9 +57,7 @@ describe('wrapCell', () => {
         it('continues cut the word by wrapWord function', () => {
           expect(wrapCell('aaa bbb\nc', 3, true)).to.deep.equal(['aaa', 'bbb', 'c']);
           expect(wrapCell('a b c\nd', 3, true)).to.deep.equal(['a b', 'c', 'd']);
-
           expect(wrapCell('aaaa\nbbbb', 3, true)).to.deep.equal(['aaa', 'a', 'bbb', 'b']);
-
           expect(wrapCell('a\\bb\nc', 3, true)).to.deep.equal(['a\\', 'bb', 'c']);
           expect(wrapCell('a/bb\nc', 3, true)).to.deep.equal(['a/', 'bb', 'c']);
           expect(wrapCell('a_bb\nc', 3, true)).to.deep.equal(['a_', 'bb', 'c']);
@@ -51,8 +65,19 @@ describe('wrapCell', () => {
           expect(wrapCell('a.bb\nc', 3, true)).to.deep.equal(['a.', 'bb', 'c']);
           expect(wrapCell('a,bb\nc', 3, true)).to.deep.equal(['a,', 'bb', 'c']);
           expect(wrapCell('a;bb\nc', 3, true)).to.deep.equal(['a;', 'bb', 'c']);
-
           expect(wrapCell('aaa-b\nc', 3, true)).to.deep.equal(['aaa', '-b', 'c']);
+
+          expect(wrapCell(stringToRed('aaa bbb\nc'), 3, true)).to.deep.equal(arrayToRed(['aaa', 'bbb', 'c']));
+          expect(wrapCell(stringToRed('a b c\nd'), 3, true)).to.deep.equal(arrayToRed(['a b', 'c', 'd']));
+          expect(wrapCell(stringToRed('aaaa\nbbbb'), 3, true)).to.deep.equal(arrayToRed(['aaa', 'a', 'bbb', 'b']));
+          expect(wrapCell(stringToRed('a\\bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a\\', 'bb', 'c']));
+          expect(wrapCell(stringToRed('a/bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a/', 'bb', 'c']));
+          expect(wrapCell(stringToRed('a_bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a_', 'bb', 'c']));
+          expect(wrapCell(stringToRed('a-bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a-', 'bb', 'c']));
+          expect(wrapCell(stringToRed('a.bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a.', 'bb', 'c']));
+          expect(wrapCell(stringToRed('a,bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a,', 'bb', 'c']));
+          expect(wrapCell(stringToRed('a;bb\nc'), 3, true)).to.deep.equal(arrayToRed(['a;', 'bb', 'c']));
+          expect(wrapCell(stringToRed('aaa-b\nc'), 3, true)).to.deep.equal(arrayToRed(['aaa', '-b', 'c']));
         });
       });
     });

--- a/test/wrapWord.ts
+++ b/test/wrapWord.ts
@@ -2,16 +2,9 @@ import {
   expect,
 } from 'chai';
 import wrapWord from '../src/wrapWord';
-
-const openRed = '\u001b[31m';
-const closeRed = '\u001b[39m';
-
-const stringToRed = (string: string) => {
-  return openRed + string + closeRed;
-};
-const arrayToRed = (array: string[]) => {
-  return array.map(stringToRed);
-};
+import {
+  arrayToRed, closeRed, openRed, stringToRed,
+} from './utils';
 
 describe('wrapWord', () => {
   it('wraps a string at a nearest whitespace', () => {
@@ -55,8 +48,8 @@ describe('wrapWord', () => {
     });
   });
 
-  context('mixed ansi', () => {
-    it('askdjhasdkj', () => {
+  context('mixed ansi and plain', () => {
+    it('returns proper strings', () => {
       expect(wrapWord(`${openRed}Lorem ${closeRed}ipsum dolor ${openRed}sit amet${closeRed}`, 5)).to.deep.equal([
         `${openRed}Lorem${closeRed}`,
         'ipsum',

--- a/test/wrapWord.ts
+++ b/test/wrapWord.ts
@@ -3,14 +3,29 @@ import {
 } from 'chai';
 import wrapWord from '../src/wrapWord';
 
+const openRed = '\u001b[31m';
+const closeRed = '\u001b[39m';
+
+const stringToRed = (string: string) => {
+  return openRed + string + closeRed;
+};
+const arrayToRed = (array: string[]) => {
+  return array.map(stringToRed);
+};
+
 describe('wrapWord', () => {
   it('wraps a string at a nearest whitespace', () => {
     expect(wrapWord('aaa bbb', 5)).to.deep.equal(['aaa', 'bbb']);
     expect(wrapWord('a a a bbb', 5)).to.deep.equal(['a a a', 'bbb']);
+
+    expect(wrapWord(stringToRed('aaa bbb'), 5)).to.deep.equal(arrayToRed(['aaa', 'bbb']));
+    expect(wrapWord(stringToRed('a a a bbb'), 5)).to.deep.equal(arrayToRed(['a a a', 'bbb']));
   });
   context('a single word is longer than chunk size', () => {
     it('cuts the word', () => {
       expect(wrapWord('aaaaa', 2)).to.deep.equal(['aa', 'aa', 'a']);
+
+      expect(wrapWord(stringToRed('aaaaa'), 2)).to.deep.equal(arrayToRed(['aa', 'aa', 'a']));
     });
   });
   context('a long word with a special character', () => {
@@ -22,11 +37,73 @@ describe('wrapWord', () => {
       expect(wrapWord('aaa.bbb', 5)).to.deep.equal(['aaa.', 'bbb']);
       expect(wrapWord('aaa,bbb', 5)).to.deep.equal(['aaa,', 'bbb']);
       expect(wrapWord('aaa;bbb', 5)).to.deep.equal(['aaa;', 'bbb']);
+
+      expect(wrapWord(stringToRed('aaa\\bbb'), 5)).to.deep.equal(arrayToRed(['aaa\\', 'bbb']));
+      expect(wrapWord(stringToRed('aaa/bbb'), 5)).to.deep.equal(arrayToRed(['aaa/', 'bbb']));
+      expect(wrapWord(stringToRed('aaa_bbb'), 5)).to.deep.equal(arrayToRed(['aaa_', 'bbb']));
+      expect(wrapWord(stringToRed('aaa-bbb'), 5)).to.deep.equal(arrayToRed(['aaa-', 'bbb']));
+      expect(wrapWord(stringToRed('aaa.bbb'), 5)).to.deep.equal(arrayToRed(['aaa.', 'bbb']));
+      expect(wrapWord(stringToRed('aaa,bbb'), 5)).to.deep.equal(arrayToRed(['aaa,', 'bbb']));
+      expect(wrapWord(stringToRed('aaa;bbb'), 5)).to.deep.equal(arrayToRed(['aaa;', 'bbb']));
     });
   });
   context('a special character after the length of a container', () => {
     it('does not include special character', () => {
       expect(wrapWord('aa-bbbbb-cccc', 5)).to.deep.equal(['aa-', 'bbbbb', '-cccc']);
+
+      expect(wrapWord(stringToRed('aa-bbbbb-cccc'), 5)).to.deep.equal(arrayToRed(['aa-', 'bbbbb', '-cccc']));
+    });
+  });
+
+  context('mixed ansi', () => {
+    it('askdjhasdkj', () => {
+      expect(wrapWord(`${openRed}Lorem ${closeRed}ipsum dolor ${openRed}sit amet${closeRed}`, 5)).to.deep.equal([
+        `${openRed}Lorem${closeRed}`,
+        'ipsum',
+        'dolor',
+        `${openRed}sit${closeRed}`,
+        `${openRed}amet${closeRed}`,
+      ]);
+
+      expect(wrapWord(`${openRed}Lorem ${closeRed}ipsum dolor ${openRed}sit amet${closeRed}`, 11)).to.deep.equal([
+        `${openRed}Lorem ${closeRed}ipsum`,
+        `dolor ${openRed}sit${closeRed}`,
+        `${openRed}amet${closeRed}`,
+      ]);
+
+      expect(wrapWord(`${openRed}Lorem ip${closeRed}sum dolor si${openRed}t amet${closeRed}`, 5)).to.deep.equal([
+        `${openRed}Lorem${closeRed}`,
+        `${openRed}ip${closeRed}sum`,
+        'dolor',
+        `si${openRed}t${closeRed}`,
+        `${openRed}amet${closeRed}`,
+      ]);
+    });
+  });
+
+  context('multiple ansi', () => {
+    it('returns proper strings', () => {
+      const openBold = '\u001b[1m';
+      const closeBold = '\u001b[22m';
+
+      expect(wrapWord(`${openBold}${openRed}Lorem ipsum dolor sit${closeRed}${closeBold}`, 4)).to.deep.equal(
+        [
+          `${openBold}${openRed}Lore${closeRed}`,
+          `${openBold}${openRed}m${closeRed}${closeBold}`,
+          `${openBold}${openRed}ipsu${closeRed}`,
+          `${openBold}${openRed}m${closeRed}${closeBold}`,
+          `${openBold}${openRed}dolo${closeRed}`,
+          `${openBold}${openRed}r${closeRed}${closeBold}`,
+          `${openBold}${openRed}sit${closeBold}${closeRed}`],
+      );
+
+      expect(wrapWord(`${openBold}${openRed}Lorem ipsum dolor sit${closeRed}${closeBold}`, 5)).to.deep.equal(
+        [
+          `${openBold}${openRed}Lorem${closeRed}${closeBold}`,
+          `${openBold}${openRed}ipsum${closeRed}${closeBold}`,
+          `${openBold}${openRed}dolor${closeRed}${closeBold}`,
+          `${openBold}${openRed}sit${closeBold}${closeRed}`],
+      );
     });
   });
 });

--- a/test/wrapWord.ts
+++ b/test/wrapWord.ts
@@ -88,11 +88,11 @@ describe('wrapWord', () => {
 
       expect(wrapWord(`${openBold}${openRed}Lorem ipsum dolor sit${closeRed}${closeBold}`, 4)).to.deep.equal(
         [
-          `${openBold}${openRed}Lore${closeRed}`,
+          `${openBold}${openRed}Lore${closeRed}${closeBold}`,
           `${openBold}${openRed}m${closeRed}${closeBold}`,
-          `${openBold}${openRed}ipsu${closeRed}`,
+          `${openBold}${openRed}ipsu${closeRed}${closeBold}`,
           `${openBold}${openRed}m${closeRed}${closeBold}`,
-          `${openBold}${openRed}dolo${closeRed}`,
+          `${openBold}${openRed}dolo${closeRed}${closeBold}`,
           `${openBold}${openRed}r${closeRed}${closeBold}`,
           `${openBold}${openRed}sit${closeBold}${closeRed}`],
       );


### PR DESCRIPTION
This PR supports ANSI word wrapping (#11). Here is my solution:
* Apply our logic on an ANSI-stripped string to get strings' lengths and offset to the next string (because of `trim`)
* Then use that information to slice real string

TODO: ~~Find out the way to split ANSI strings by newline character in `wrapCell.ts`~~