### PR TITLE
[refactor] Remove unreal string type guards

### DIFF
--- a/src/alignString.ts
+++ b/src/alignString.ts
@@ -30,10 +30,6 @@ const alignCenter = (subject: string, width: number): string => {
  * text in a desired alignment within a container.
  */
 export default (subject: string, containerWidth: number, alignment: ColumnUserConfig['alignment']): string => {
-  if (typeof subject !== 'string') {
-    throw new TypeError('Subject parameter value must be a string.');
-  }
-
   const subjectWidth = stringWidth(subject);
 
   if (subjectWidth > containerWidth) {

--- a/src/calculateCellHeight.ts
+++ b/src/calculateCellHeight.ts
@@ -1,9 +1,5 @@
 import wrapCell from './wrapCell';
 
 export default (value: string, columnWidth: number, useWrapWord = false): number => {
-  if (typeof value !== 'string') {
-    throw new TypeError('Value must be a string.');
-  }
-
   return wrapCell(value, columnWidth, useWrapWord).length;
 };

--- a/test/alignString.ts
+++ b/test/alignString.ts
@@ -7,14 +7,6 @@ import chalk from 'chalk';
 import alignString from '../src/alignString';
 
 describe('alignString', () => {
-  context('subject parameter value is not a string', () => {
-    it('throws an error', () => {
-      expect(() => {
-        alignString(2 as never, 1, 'left');
-      }).to.throw(Error, 'Subject parameter value must be a string.');
-    });
-  });
-
   context('subject parameter value width is greater than the container width', () => {
     it('throws an error', () => {
       expect(() => {

--- a/test/calculateCellHeight.ts
+++ b/test/calculateCellHeight.ts
@@ -7,13 +7,6 @@ import calculateCellHeight from '../src/calculateCellHeight';
 
 describe('calculateCellHeight', () => {
   describe('value', () => {
-    context('is not a string', () => {
-      it('throws an error', () => {
-        expect(() => {
-          calculateCellHeight(null as never, 10);
-        }).to.throw(Error, 'Value must be a string.');
-      });
-    });
     it('contains newlines', () => {
       expect(calculateCellHeight('a\nb\nc', 10)).to.equal(3);
     });


### PR DESCRIPTION
It's weird to check whether a string parameter is a _real_ string in the compile-time and run-time (because all data is converted to strings at the beginning).