### PR TITLE
[feat] Support justify alignment

### DIFF
--- a/.README/usage/cell_content_alignment.md
+++ b/.README/usage/cell_content_alignment.md
@@ -2,7 +2,7 @@
 
 `{string} config.columns[{number}].alignment` property controls content horizontal alignment within a cell.
 
-Valid values are: "left", "right" and "center".
+Valid values are: "left", "right", "center" and "justify".
 
 ```js
 let config,
@@ -10,26 +10,21 @@ let config,
   output;
 
 data = [
-  ['0A', '0B', '0C'],
-  ['1A', '1B', '1C'],
-  ['2A', '2B', '2C']
+  ['0A', '0B', '0C', '0D 0E 0F'],
+  ['1A', '1B', '1C', '1D 1E 1F'],
+  ['2A', '2B', '2C', '2D 2E 2F'],
 ];
 
 config = {
-  columns: {
-    0: {
-      alignment: 'left',
-      width: 10
-    },
-    1: {
-      alignment: 'center',
-      width: 10
-    },
-    2: {
-      alignment: 'right',
-      width: 10
-    }
-  }
+  columnDefault: {
+    width: 10,
+  },
+  columns: [
+    {alignment: 'left'},
+    {alignment: 'center'},
+    {alignment: 'right'},
+    {alignment: 'justify'},
+  ],
 };
 
 output = table(data, config);
@@ -38,11 +33,11 @@ console.log(output);
 ```
 
 ```
-╔════════════╤════════════╤════════════╗
-║ 0A         │     0B     │         0C ║
-╟────────────┼────────────┼────────────╢
-║ 1A         │     1B     │         1C ║
-╟────────────┼────────────┼────────────╢
-║ 2A         │     2B     │         2C ║
-╚════════════╧════════════╧════════════╝
+╔════════════╤════════════╤════════════╤════════════╗
+║ 0A         │     0B     │         0C │ 0D  0E  0F ║
+╟────────────┼────────────┼────────────┼────────────╢
+║ 1A         │     1B     │         1C │ 1D  1E  1F ║
+╟────────────┼────────────┼────────────┼────────────╢
+║ 2A         │     2B     │         2C │ 2D  2E  2F ║
+╚════════════╧════════════╧════════════╧════════════╝
 ```

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ console.log(output);
 
 `{string} config.columns[{number}].alignment` property controls content horizontal alignment within a cell.
 
-Valid values are: "left", "right" and "center".
+Valid values are: "left", "right", "center" and "justify".
 
 ```js
 let config,
@@ -163,26 +163,21 @@ let config,
   output;
 
 data = [
-  ['0A', '0B', '0C'],
-  ['1A', '1B', '1C'],
-  ['2A', '2B', '2C']
+  ['0A', '0B', '0C', '0D 0E 0F'],
+  ['1A', '1B', '1C', '1D 1E 1F'],
+  ['2A', '2B', '2C', '2D 2E 2F'],
 ];
 
 config = {
-  columns: {
-    0: {
-      alignment: 'left',
-      width: 10
-    },
-    1: {
-      alignment: 'center',
-      width: 10
-    },
-    2: {
-      alignment: 'right',
-      width: 10
-    }
-  }
+  columnDefault: {
+    width: 10,
+  },
+  columns: [
+    {alignment: 'left'},
+    {alignment: 'center'},
+    {alignment: 'right'},
+    {alignment: 'justify'},
+  ],
 };
 
 output = table(data, config);
@@ -191,13 +186,13 @@ console.log(output);
 ```
 
 ```
-╔════════════╤════════════╤════════════╗
-║ 0A         │     0B     │         0C ║
-╟────────────┼────────────┼────────────╢
-║ 1A         │     1B     │         1C ║
-╟────────────┼────────────┼────────────╢
-║ 2A         │     2B     │         2C ║
-╚════════════╧════════════╧════════════╝
+╔════════════╤════════════╤════════════╤════════════╗
+║ 0A         │     0B     │         0C │ 0D  0E  0F ║
+╟────────────┼────────────┼────────────┼────────────╢
+║ 1A         │     1B     │         1C │ 1D  1E  1F ║
+╟────────────┼────────────┼────────────┼────────────╢
+║ 2A         │     2B     │         2C │ 2D  2E  2F ║
+╚════════════╧════════════╧════════════╧════════════╝
 ```
 
 <a name="table-usage-column-width"></a>

--- a/src/alignString.ts
+++ b/src/alignString.ts
@@ -1,7 +1,10 @@
 import stringWidth from 'string-width';
 import type {
-  ColumnUserConfig,
+  Alignment,
 } from './types/api';
+import {
+  countSpaceSequence, distributeUnevenly,
+} from './utils';
 
 const alignLeft = (subject: string, width: number): string => {
   return subject + ' '.repeat(width);
@@ -25,11 +28,31 @@ const alignCenter = (subject: string, width: number): string => {
   }
 };
 
+const alignJustify = (subject: string, width: number): string => {
+  const spaceSequenceCount = countSpaceSequence(subject);
+
+  if (spaceSequenceCount === 0) {
+    return alignLeft(subject, width);
+  }
+
+  const addingSpaces = distributeUnevenly(width, spaceSequenceCount);
+
+  if (Math.max(...addingSpaces) > 3) {
+    return alignLeft(subject, width);
+  }
+
+  let spaceSequenceIndex = 0;
+
+  return subject.replace(/\s+/g, (groupSpace) => {
+    return groupSpace + ' '.repeat(addingSpaces[spaceSequenceIndex++]);
+  });
+};
+
 /**
  * Pads a string to the left and/or right to position the subject
  * text in a desired alignment within a container.
  */
-export const alignString = (subject: string, containerWidth: number, alignment: ColumnUserConfig['alignment']): string => {
+export const alignString = (subject: string, containerWidth: number, alignment: Alignment): string => {
   const subjectWidth = stringWidth(subject);
 
   if (subjectWidth > containerWidth) {
@@ -48,6 +71,10 @@ export const alignString = (subject: string, containerWidth: number, alignment: 
 
   if (alignment === 'right') {
     return alignRight(subject, availableWidth);
+  }
+
+  if (alignment === 'justify') {
+    return alignJustify(subject, availableWidth);
   }
 
   return alignCenter(subject, availableWidth);

--- a/src/schemas/shared.json
+++ b/src/schemas/shared.json
@@ -29,7 +29,8 @@
                     "enum": [
                         "left",
                         "right",
-                        "center"
+                        "center",
+                        "justify"
                     ]
                 },
                 "width": {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -25,12 +25,14 @@ export type BorderUserConfig = {
 
 export type BorderConfig = Required<BorderUserConfig>;
 
+export type Alignment = 'center' | 'justify' | 'left' | 'right';
+
 export type ColumnUserConfig = {
 
   /**
    * Cell content horizontal alignment (default: left)
    */
-  readonly alignment?: 'center' | 'left' | 'right',
+  readonly alignment?: Alignment,
 
   /**
    * Column width (default: auto calculation based on the cell content)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,3 +70,32 @@ export const groupBySizes = <T>(array: T[], sizes: number[]): T[][] => {
     return group;
   });
 };
+
+/**
+ * Counts the number of continuous spaces in a string
+ *
+ * @internal
+ * @example
+ * countGroupSpaces('a  bc  de f') = 3
+ */
+export const countSpaceSequence = (input: string): number => {
+  return input.match(/\s+/g)?.length ?? 0;
+};
+
+/**
+ * Creates the non-increasing number array given sum and length
+ * whose the difference between maximum and minimum is not greater than 1
+ *
+ * @internal
+ * @example
+ * distributeUnevenly(6, 3) = [2, 2, 2]
+ * distributeUnevenly(8, 3) = [3, 3, 2]
+ */
+export const distributeUnevenly = (sum: number, length: number): number[] => {
+  const result = Array.from<number>({length}).fill(Math.floor(sum / length));
+
+  return result.map((element, index) => {
+    return element + (index < sum % length ? 1 : 0);
+  });
+};
+

--- a/test/README/usage/cellContentAlignment.ts
+++ b/test/README/usage/cellContentAlignment.ts
@@ -9,38 +9,33 @@ import expectTable from './expectTable';
 describe('README.md usage/', () => {
   it('cell_content_alignment', () => {
     const data = [
-      ['0A', '0B', '0C'],
-      ['1A', '1B', '1C'],
-      ['2A', '2B', '2C'],
+      ['0A', '0B', '0C', '0D 0E 0F'],
+      ['1A', '1B', '1C', '1D 1E 1F'],
+      ['2A', '2B', '2C', '2D 2E 2F'],
     ];
 
     const config: TableUserConfig = {
-      columns: {
-        0: {
-          alignment: 'left',
-          width: 10,
-        },
-        1: {
-          alignment: 'center',
-          width: 10,
-        },
-        2: {
-          alignment: 'right',
-          width: 10,
-        },
+      columnDefault: {
+        width: 10,
       },
+      columns: [
+        {alignment: 'left'},
+        {alignment: 'center'},
+        {alignment: 'right'},
+        {alignment: 'justify'},
+      ],
     };
 
     const output = table(data, config);
 
     expectTable(output, `
-╔════════════╤════════════╤════════════╗
-║ 0A         │     0B     │         0C ║
-╟────────────┼────────────┼────────────╢
-║ 1A         │     1B     │         1C ║
-╟────────────┼────────────┼────────────╢
-║ 2A         │     2B     │         2C ║
-╚════════════╧════════════╧════════════╝
+╔════════════╤════════════╤════════════╤════════════╗
+║ 0A         │     0B     │         0C │ 0D  0E  0F ║
+╟────────────┼────────────┼────────────┼────────────╢
+║ 1A         │     1B     │         1C │ 1D  1E  1F ║
+╟────────────┼────────────┼────────────┼────────────╢
+║ 2A         │     2B     │         2C │ 2D  2E  2F ║
+╚════════════╧════════════╧════════════╧════════════╝
         `);
   });
 });

--- a/test/README/usage/moonMission.ts
+++ b/test/README/usage/moonMission.ts
@@ -60,7 +60,9 @@ describe('README.md usage/', () => {
       border: tableBorder,
       columns: {
         4: {
+          alignment: 'justify',
           width: 50,
+          wrapWord: true,
         },
       },
     });

--- a/test/alignString.ts
+++ b/test/alignString.ts
@@ -7,6 +7,9 @@ import chalk from 'chalk';
 import {
   alignString,
 } from '../src/alignString';
+import {
+  stringToRed,
+} from './utils';
 
 describe('alignString', () => {
   context('subject parameter value width is greater than the container width', () => {
@@ -22,6 +25,7 @@ describe('alignString', () => {
       it('produces a string consisting of container width number of whitespace characters', () => {
         expect(alignString('', 5, 'left')).to.equal('     ', 'left');
         expect(alignString('', 5, 'center')).to.equal('     ', 'center');
+        expect(alignString('', 5, 'justify')).to.equal('     ', 'justify');
         expect(alignString('', 5, 'right')).to.equal('     ', 'right');
       });
     });
@@ -47,6 +51,34 @@ describe('alignString', () => {
             });
           });
         });
+
+        context('justify', () => {
+          it('align left if not contain spaces', () => {
+            expect(alignString('aa', 5, 'justify')).to.equal('aa   ');
+          });
+
+          it('add missing spaces between two words', () => {
+            expect(alignString('a a', 5, 'justify')).to.equal('a   a');
+            expect(alignString('a  a', 5, 'justify')).to.equal('a   a');
+            expect(alignString('a   a', 5, 'justify')).to.equal('a   a');
+          });
+
+          it('multiple words, distribute spaces from left to right when maximum adding spaces in one place are not greater than 3', () => {
+            expect(alignString('a b c', 5, 'justify')).to.equal('a b c');
+            expect(alignString('a b c', 6, 'justify')).to.equal('a  b c');
+            expect(alignString('a b c', 7, 'justify')).to.equal('a  b  c');
+            expect(alignString('a b c', 8, 'justify')).to.equal('a   b  c');
+            expect(alignString('a b c', 9, 'justify')).to.equal('a   b   c');
+            expect(alignString('a b c', 10, 'justify')).to.equal('a    b   c');
+            expect(alignString('a b c', 11, 'justify')).to.equal('a    b    c');
+            expect(alignString('a b c', 12, 'justify')).to.equal('a b c       ');
+
+            expect(alignString('a  bbb cc d', 11, 'justify')).to.equal('a  bbb cc d');
+            expect(alignString('a  bbb cc d', 12, 'justify')).to.equal('a   bbb cc d');
+            expect(alignString('a  bbb cc d', 13, 'justify')).to.equal('a   bbb  cc d');
+            expect(alignString('a  bbb cc d', 14, 'justify')).to.equal('a   bbb  cc  d');
+          });
+        });
       });
     });
     context('text containing ANSI escape codes', () => {
@@ -69,6 +101,31 @@ describe('alignString', () => {
             it('floors the available width; adds extra space to the end of the string', () => {
               expect(alignString(chalk.red('aa'), 7, 'center')).to.equal('  ' + chalk.red('aa') + '   ');
             });
+          });
+        });
+        context('justify', () => {
+          it('align left if not contain spaces', () => {
+            expect(alignString(chalk.red('aa'), 5, 'justify')).to.equal(chalk.red('aa') + '   ');
+          });
+
+          it('add missing spaces between two words', () => {
+            expect(alignString(stringToRed('a a'), 5, 'justify')).to.equal(stringToRed('a   a'));
+            expect(alignString(stringToRed('a  a'), 5, 'justify')).to.equal(stringToRed('a   a'));
+            expect(alignString(stringToRed('a   a'), 5, 'justify')).to.equal(stringToRed('a   a'));
+          });
+
+          it('multiple words, uneven spaces add from left to right', () => {
+            expect(alignString(stringToRed('a b c'), 5, 'justify')).to.equal(stringToRed('a b c'));
+            expect(alignString(stringToRed('a b c'), 6, 'justify')).to.equal(stringToRed('a  b c'));
+            expect(alignString(stringToRed('a b c'), 7, 'justify')).to.equal(stringToRed('a  b  c'));
+            expect(alignString(stringToRed('a b c'), 8, 'justify')).to.equal(stringToRed('a   b  c'));
+            expect(alignString(stringToRed('a b c'), 9, 'justify')).to.equal(stringToRed('a   b   c'));
+            expect(alignString(stringToRed('a b c'), 10, 'justify')).to.equal(stringToRed('a    b   c'));
+
+            expect(alignString(stringToRed('a  bbb cc d'), 11, 'justify')).to.equal(stringToRed('a  bbb cc d'));
+            expect(alignString(stringToRed('a  bbb cc d'), 12, 'justify')).to.equal(stringToRed('a   bbb cc d'));
+            expect(alignString(stringToRed('a  bbb cc d'), 13, 'justify')).to.equal(stringToRed('a   bbb  cc d'));
+            expect(alignString(stringToRed('a  bbb cc d'), 14, 'justify')).to.equal(stringToRed('a   bbb  cc  d'));
           });
         });
       });

--- a/test/configSamples.ts
+++ b/test/configSamples.ts
@@ -134,6 +134,7 @@ const configSamples: {invalid: unknown[], valid: TableUserConfig[], } = {
     {columns: {0: {alignment: 'left'}}},
     {columns: {1: {alignment: 'right'}}},
     {columns: {2: {alignment: 'center'}}},
+    {columns: {3: {alignment: 'justify'}}},
     {border: {topBody: '-'}},
     {border: {topJoin: '-'}},
     {border: {topLeft: '-'}},

--- a/test/streamConfigSamples.ts
+++ b/test/streamConfigSamples.ts
@@ -162,6 +162,11 @@ const streamConfigSamples: {invalid: unknown[], valid: StreamUserConfig[], } = {
     },
     {
       columnCount: 3,
+      columnDefault: {width: 20},
+      columns: {2: {alignment: 'justify'}},
+    },
+    {
+      columnCount: 3,
       columnDefault: {
         width: 20,
       },


### PR DESCRIPTION
This PR adds the justify alignment feature (#167). The solution is to calculate the number array of adding spaces, which has a length that is equal to the number of continuous space sequences and has a sum is equal to the available width. To be prettier, the array should be a non-decreasing one, and the difference between the maximum and minimum value is not greater than 1.

Example with total width = 10:
```js
alignString('a b c')     = 'a    b   c'
alignString('a b c d')   = 'a  b  c  d'
alignString('a b c d e') = 'a  b c d e'
```

The issue is when the string is too short (e.g., the last line of a paragraph), I propose to fallback to left align if we have to add more than 03 spaces in one place (instead of calculating more information about the surrounding lines). So:

```js
alignString('a b c', 11, 'justify')     = 'a    b    c'
alignString('a b c', 12, 'justify')     = 'a b c       '

```

Here is the demo from moonMission file with justify the last column:
<img width="984" alt="image" src="https://user-images.githubusercontent.com/28835226/116168820-81530280-a72d-11eb-91d1-0bc669e643c3.png">


