### PR TITLE
Update section links in README to work in both GitHub and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/kuizinas.svg?style=social&label=Follow)](https://twitter.com/kuizinas)
 
 * [Table](#table)
-    * [Features](#table-features)
-    * [Install](#table-install)
-    * [Usage](#table-usage)
-    * [API](#table-api)
-        * [table](#table-api-table-1)
-        * [createStream](#table-api-createstream)
-        * [getBorderCharacters](#table-api-getbordercharacters)
+    * [Features](#features)
+    * [Install](#install)
+    * [Usage](#usage)
+    * [API](#api)
+        * [table](#table-1)
+        * [createStream](#createstream)
+        * [getBorderCharacters](#getbordercharacters)
 
 
 ![Demo of table displaying a list of missions to the Moon.](./.README/demo.png)


### PR DESCRIPTION
Previous links to sections of the document only works on GitHub, but not npm, this patch aims to fix the issue.