### PR TITLE
fix: allow readonly array input for table data

### DIFF
--- a/src/stringifyTableData.ts
+++ b/src/stringifyTableData.ts
@@ -5,7 +5,7 @@ import {
   normalizeString,
 } from './utils';
 
-export const stringifyTableData = (rows: unknown[][]): Row[] => {
+export const stringifyTableData = (rows: ReadonlyArray<readonly unknown[]>): Row[] => {
   return rows.map((cells) => {
     return cells.map((cell) => {
       return normalizeString(String(cell));

--- a/src/table.ts
+++ b/src/table.ts
@@ -38,7 +38,7 @@ import {
   validateTableData,
 } from './validateTableData';
 
-export const table = (data: unknown[][], userConfig: TableUserConfig = {}): string => {
+export const table = (data: ReadonlyArray<readonly unknown[]>, userConfig: TableUserConfig = {}): string => {
   validateTableData(data);
 
   let rows = stringifyTableData(data);

--- a/src/validateTableData.ts
+++ b/src/validateTableData.ts
@@ -2,7 +2,7 @@ import {
   normalizeString,
 } from './utils';
 
-export const validateTableData = (rows: unknown[][]): void => {
+export const validateTableData = (rows: ReadonlyArray<readonly unknown[]>): void => {
   if (!Array.isArray(rows)) {
     throw new TypeError('Table data must be an array.');
   }

--- a/test/table.ts
+++ b/test/table.ts
@@ -187,4 +187,21 @@ describe('drawTable', () => {
 ╚══════════╧══════════╧══════════╧══════════╝`);
     });
   });
+
+  context('readonly array data type input', () => {
+    it('works properly', () => {
+      const dataReadonly = data as ReadonlyArray<readonly string[]>;
+
+      const result = table(dataReadonly);
+
+      expectTable(result, `
+╔═════════════╤═════════════╗
+║ Lorem ipsum │ dolor sit   ║
+╟─────────────┼─────────────╢
+║ amet        │ consectetur ║
+╟─────────────┼─────────────╢
+║ adipiscing  │ elit        ║
+╚═════════════╧═════════════╝`);
+    });
+  });
 });


### PR DESCRIPTION
This is the minimum set of changes needed to allow a readonly array to be passed as input to the public `table()` function, in addition to regular arrays (backward compatible).

Some users may prefer to declare their arrays as readonly, or use functions/libraries that return readonly arrays when generating the table data. This change improves compatibility for such users.

It's also generally good practice for us to enforce that we do not modify input parameters.

Potential follow-up changes:
* There's a public `spanningCells` option that could be changed to use a readonly array. This would require a minor change to avoid mutating the input array by cloning it first.
* There are dozens of other private/internal places throughout the codebase where additional readonly array types could be used as a best practice if desired. In some cases, this would require rewriting code to avoid mutating arrays.

References:
* https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#improvements-for-readonlyarray-and-readonly-tuples
* https://github.com/wooorm/markdown-table/pull/30
