### PR TITLE
fix: Generate larger tables more quickly

### DIFF
--- a/src/spanningCellManager.ts
+++ b/src/spanningCellManager.ts
@@ -21,7 +21,7 @@ import type {
 } from './types/internal';
 import {
   areCellEqual,
-  findOriginalRowIndex,
+  flatten,
   isCellInRange, sequence, sumArray,
 } from './utils';
 
@@ -30,6 +30,8 @@ export type SpanningCellManager = {
   inSameRange: (cell1: CellCoordinates, cell2: CellCoordinates) => boolean,
   rowHeights: number[],
   setRowHeights: (rowHeights: number[]) => void,
+  rowIndexMapping: number[],
+  setRowIndexMapping: (mappedRowHeights: number[]) => void,
 };
 
 export type SpanningCellParameters = {
@@ -114,9 +116,10 @@ export const createSpanningCellManager = (parameters: SpanningCellParameters): S
   const rangeCache: Record<string, ResolvedRangeConfig | undefined> = {};
 
   let rowHeights: number[] = [];
+  let rowIndexMapping: number[] = [];
 
   return {getContainingRange: (cell, options) => {
-    const originalRow = options?.mapped ? findOriginalRowIndex(rowHeights, cell.row) : cell.row;
+    const originalRow = options?.mapped ? rowIndexMapping[cell.row] : cell.row;
 
     const range = findRangeConfig({...cell,
       row: originalRow}, ranges);
@@ -139,7 +142,15 @@ export const createSpanningCellManager = (parameters: SpanningCellParameters): S
     return inSameRange(cell1, cell2, ranges);
   },
   rowHeights,
+  rowIndexMapping,
   setRowHeights: (_rowHeights: number[]) => {
     rowHeights = _rowHeights;
+  },
+  setRowIndexMapping: (mappedRowHeights: number[]) => {
+    rowIndexMapping = flatten(mappedRowHeights.map((height, index) => {
+      return Array.from({length: height}, () => {
+        return index;
+      });
+    }));
   }};
 };

--- a/src/table.ts
+++ b/src/table.ts
@@ -52,6 +52,7 @@ export const table = (data: unknown[][], userConfig: TableUserConfig = {}): stri
   const rowHeights = calculateRowHeights(rows, config);
 
   config.spanningCellManager.setRowHeights(rowHeights);
+  config.spanningCellManager.setRowIndexMapping(rowHeights);
 
   rows = mapDataUsingRowHeights(rows, rowHeights, config);
   rows = alignTableData(rows, config);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,16 +127,6 @@ export const flatten = <T>(array: T[][]): T[] => {
   return ([] as T[]).concat(...array);
 };
 
-export const findOriginalRowIndex = (mappedRowHeights: number[], mappedRowIndex: number): number => {
-  const rowIndexMapping = flatten(mappedRowHeights.map((height, index) => {
-    return Array.from({length: height}, () => {
-      return index;
-    });
-  }));
-
-  return rowIndexMapping[mappedRowIndex];
-};
-
 export const calculateRangeCoordinate = (spanningCellConfig: SpanningCellConfig): RangeCoordinate => {
   const {row, col, colSpan = 1, rowSpan = 1} = spanningCellConfig;
 


### PR DESCRIPTION
Testing locally, this change dropped the time taken for a large (3256 line) table from ~12 seconds to ~0.25 seconds.

Previously `table` was recreating the `rowIndexMapping` for each row. It looks like the mapping is the same each time, so I've moved the work up to happen only once, with the result stored in `spanningCellManager`.

Refs #223 