### PR TITLE
Add "module" to emulate both commonjs/esm at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   ],
   "license": "BSD-3-Clause",
   "main": "./dist/src/index.js",
+  "module": "./dist/src/index.js",
   "files": [
     "dist/src/"
   ],


### PR DESCRIPTION
Add "module" to emulate both commonjs/esm at package.json

With "sideEffects" help bundlers cut unused code, when use named imports