### PR TITLE
Performance of calculateCellHeights

### DIFF
--- a/src/calculateCellHeight.ts
+++ b/src/calculateCellHeight.ts
@@ -1,10 +1,31 @@
-import {
-  wrapCell,
-} from './wrapCell';
+import stripAnsi from "strip-ansi";
 
 /**
  * Calculates height of cell content in regard to its width and word wrapping.
  */
 export const calculateCellHeight = (value: string, columnWidth: number, useWrapWord = false): number => {
-  return wrapCell(value, columnWidth, useWrapWord).length;
+  if (value.length === 0) {
+    return 1;
+  }
+  const strippedValue = stripAnsi(value);
+  const size = Math.max(1, columnWidth);
+
+  const pattern = useWrapWord ?
+    new RegExp(`(.{0,${size - 1}}(?:(?:.\\s|[\\\\\\/_\\.,;-]|.$))|.{0,${size}}\\s?)`, 'g') :
+    new RegExp(`(.{0,${size}}\\s*)`, 'g');
+
+  let count = 0;
+  let match;
+
+  while ((match = pattern.exec(strippedValue)) !== null) {
+    if (match[0] || match.index === strippedValue.length && strippedValue.endsWith('\n')) {
+      count++;
+    }
+
+    if (match.index === pattern.lastIndex) {
+      pattern.lastIndex++;
+    }
+  }
+
+  return count || 1;
 };

--- a/test/calculateRowHeights.ts
+++ b/test/calculateRowHeights.ts
@@ -1,6 +1,9 @@
 /* eslint-disable max-nested-callbacks */
 
 import {
+  performance,
+} from 'perf_hooks';
+import {
   expect,
 } from 'chai';
 import {
@@ -70,6 +73,32 @@ describe('calculateRowHeights', () => {
 
         expect(rowHeights[0]).to.equal(3);
       });
+    });
+  });
+  context('performance', () => {
+    it('processes 1000 rows with 100 newlines each in under 100 ms', () => {
+      const data = Array.from({length: 1_000}, () => {
+        return ['!', '?\n'.repeat(100)];
+      });
+
+      const config = makeTableConfig(data, {
+        columns: {
+          0: {
+            width: 10,
+            wrapWord: false,
+          },
+        },
+      });
+
+      const startTime = performance.now();
+      const rowHeights = calculateRowHeights(data, config);
+      const endTime = performance.now();
+
+      const executionTime = endTime - startTime;
+
+      expect(executionTime).to.be.lessThan(50);
+      expect(rowHeights).to.have.length(1_000);
+      expect(rowHeights[0]).to.equal(101);
     });
   });
 });


### PR DESCRIPTION
## 🐛 Issue

When rendering large datasets that contain **newline characters**, there is **significant performance degradation**.  
This is caused by excessive **GC pressure** due to unnecessary `.split()` and `.splice()` operations during wrapping and height calculations.

---

## 🧪 Current Workaround

To mitigate the issue in production use, I implemented a **lazy-loading approach** for rendering tables (e.g., recent traceback list), loading content in parts and **merging the final table at runtime**.

---

## ✅ Proposed Solution

Optimize the height calculation logic by using a **regex `.exec()` in a loop** instead of `.split()` and `.wrap()` to count line breaks.  
This avoids allocating large arrays and reduces GC overhead during render-heavy scenarios.

---

## 🔍 What Could Be Improved

- **Regex optimizations**: Current regex expressions in `wrap*` functions could be reviewed and optimized for better performance.
- **Memoization opportunities**:
  - Splitting and wrapping operations could potentially be **memoized**.
  - Alternatively, these computations might be moved **outside of the render cycle** if inputs don’t change.
  - Needs further investigation.
- **Potential side effects**:
  - The solution introduces a **looser coupling with the wrapping algorithm**, which may lead to unexpected rendering behavior in some edge cases.
  - Consider making this height calculation strategy **configurable**, so it can be enabled explicitly when needed.
